### PR TITLE
make slf4j impl. optional dependency, so it doesn't break end user logging

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -54,6 +54,8 @@
   		<groupId>org.slf4j</groupId>
   		<artifactId>slf4j-simple</artifactId>
   		<version>1.7.12</version>
+  		<optional>true</optional>
+  		<scope>runtime</scope>
   	</dependency>
   	<dependency>
   		<groupId>commons-io</groupId>


### PR DESCRIPTION
A small fix.
We had to exclude this particular dependency in our project, because it was randomly overriding our own configuration, resulting in missing log files of our service. I believe that as a library you should only include the SLF4J API. See http://www.slf4j.org/faq.html#configure_logging