### PR TITLE
Don't log InterruptedException during shutdown

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -315,7 +315,10 @@ public class Daemon {
                         updateCredentials();
                         Thread.sleep(config.getCredentialsRefreshDelay());
                     } catch (InterruptedException e) {
-                        log.warn("Exception during updateCredentials", e);
+
+                        if (!shutdown.get()) { // Don't log InterruptedException raised during shutdown process
+                            log.warn("Exception during updateCredentials", e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I have noticed that sometimes during KPL shutdown an InterruptedException exception is logged from updateCredentials wait cycle. I believe there is no need to log it as warning during normal shutdown process. 
