### PR TITLE
Add SNI extension to TLS connections

### DIFF
--- a/aws/http/io_service_socket.h
+++ b/aws/http/io_service_socket.h
@@ -170,6 +170,8 @@ class IoServiceSocket : public Socket {
       return;
     }
 
+    SSL_set_tlsext_host_name(ssl_socket_->native_handle(), endpoint_.c_str());
+
     ssl_socket_->async_handshake(
         boost::asio::ssl::stream_base::client,
         [this](auto& ec) { this->on_connect_finish(ec); });


### PR DESCRIPTION
This adds the SNI extension to the TLS connections produced by the http_client. This also allows for proxying of these connections, potentially solving #13.
