### PR TITLE
kinesis and cloudwatch endpoint patch for China region

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Significant platform compatibility improvements and easier credentials configura
 + The `Configuration` class has been renamed `KinesisProducerConfiguration`.
 + `KinesisProducerConfiguration` now accepts the AWS Java SDK's `AWSCredentialsProvider` instances for configuring credentials.
 + In addition, a different set of credentials can now be provided for uploading metrics.
++ For working with China region, set BOTH customEndpoint (e.g: kinesis.cn-north-1.amazonaws.com.cn) and region (e.g: cn-north-1) properties in KinesisProducerConfiguration.
 
 #### C++ Core
 

--- a/aws/metrics/metrics_manager.h
+++ b/aws/metrics/metrics_manager.h
@@ -128,7 +128,7 @@ class MetricsManager {
       : executor_(std::move(executor)),
         endpoint_(custom_endpoint.empty()
                       ? "monitoring." + region + ".amazonaws.com"
-                      : custom_endpoint),
+                      : custom_endpoint.replace(0,7,"monitoring")),
         http_client_(
             std::make_shared<aws::http::HttpClient>(
                 executor_,


### PR DESCRIPTION
This patch fix Issue#36:
If set customEndpoint to "kinesis.cn-north-1.amazonaws.com.cn" the cloudwatch metrics will be sent to "kinesis.cn-north-1.amazonaws.com.cn" as well.

This patch actually workaround Issue#28.

Please diff README.md for detail.
