### PR TITLE
Resolves #59: add configuration property to explicitly configure LD_LIBRARY_PATH for the native process

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -782,7 +782,7 @@ public class KinesisProducer {
             if (binPath != null && !binPath.trim().isEmpty()) {
                 pathToExecutable = binPath.trim();
                 log.warn("Using non-default native binary at " + pathToExecutable);
-                pathToLibDir = "";
+                pathToLibDir = config.getLibraryPath() == null ? "" : config.getLibraryPath();
             } else {
                 log.info("Extracting binaries to " + tmpDir);
                 try {
@@ -820,8 +820,8 @@ public class KinesisProducer {
                         }
                         extracted.setExecutable(true);
                     }
-     
-                    pathToLibDir = pathToTmpDir;
+
+                    pathToLibDir = config.getLibraryPath() == null ? pathToTmpDir : config.getLibraryPath();
                 } catch (Exception e) {
                     throw new RuntimeException("Could not copy native binaries to temp directory " + tmpDir, e);
                 }

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -252,6 +252,7 @@ public class KinesisProducerConfiguration {
     private long requestTimeout = 6000L;
     private String tempDirectory = "";
     private boolean verifyCertificate = true;
+    private String libraryPath;
 
     /**
      * Enable aggregation. With aggregation, multiple user records are packed into a single
@@ -675,6 +676,17 @@ public class KinesisProducerConfiguration {
      */
     public boolean isVerifyCertificate() {
       return verifyCertificate;
+    }
+
+    /**
+     * Library path (only useful for Unix-like systems).
+     * Will be propagated to LD_LIBRARY_PATH and DYLD_LIBRARY_PATH environment variables of the child process.
+     *
+     * <p><b>Default</b>: null
+     */
+
+    public String getLibraryPath() {
+        return libraryPath;
     }
 
     /**
@@ -1186,6 +1198,16 @@ public class KinesisProducerConfiguration {
         return this;
     }
 
+    /**
+     * Library path (only useful for Unix-like systems).
+     * Will be propagated to LD_LIBRARY_PATH and DYLD_LIBRARY_PATH environment variables of the child process.
+     *
+     * <p><b>Default</b>: null
+     */
+    public KinesisProducerConfiguration setLibraryPath(String val) {
+        libraryPath = val;
+        return this;
+    }
 
     protected Message toProtobufMessage() {
         Configuration c = this.additionalConfigsToProtobuf(


### PR DESCRIPTION
This is a trivial change allowing users to explicitly set library path (via LD_LIBRARY_PATH environment variable). This is required on some systems without `ld.so.conf` (i.e., Boxfuse) for the native executable to function properly. Default behavior (without setting this property) is unaffected.
