### PR TITLE
Don't Include System Default CA Bundle

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -162,7 +162,7 @@ if [ ! -d "curl-7.47.0" ]; then
   cd curl-7.47.0
 
   conf --disable-shared --disable-ldap --disable-ldaps \
-    --enable-threaded-resolver --disable-debug --without-libssh2
+    --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle
   make -j
   make install
 


### PR DESCRIPTION
Curl by default will include the system CA bundle, and will pass that to
OpenSSL when configuring the connection.  Unfortunately when OpenSSL
get a CA File that it can't open, it never event attempts to use the CA
Directory parameter.