### PR TITLE
Don't report SIGPIPE as an error

### DIFF
--- a/aws/utils/backtrace/backtrace.h
+++ b/aws/utils/backtrace/backtrace.h
@@ -1,3 +1,16 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 #ifndef VARIED_BACKTRACE_H
 #define VARIED_BACKTRACE_H
 

--- a/aws/utils/backtrace/bsd_backtrace.cc
+++ b/aws/utils/backtrace/bsd_backtrace.cc
@@ -1,3 +1,16 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
 #include <execinfo.h>

--- a/aws/utils/backtrace/gcc_backtrace.cc
+++ b/aws/utils/backtrace/gcc_backtrace.cc
@@ -1,3 +1,16 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
 #include <execinfo.h>

--- a/aws/utils/backtrace/null_backtrace.cc
+++ b/aws/utils/backtrace/null_backtrace.cc
@@ -1,3 +1,16 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
 #include <execinfo.h>

--- a/aws/utils/signal_handler.h
+++ b/aws/utils/signal_handler.h
@@ -1,6 +1,15 @@
+// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
-// Created by Pfifer, Justin on 4/29/16.
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
 //
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
 
 #ifndef AMAZON_KINESIS_PRODUCER_INTERNAL_SIGNAL_HANDLER_H
 #define AMAZON_KINESIS_PRODUCER_INTERNAL_SIGNAL_HANDLER_H

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.1</version>
+    <version>0.12.2-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>


### PR DESCRIPTION
Set signal handling to ignore SIGPIPE.  This will prevent a spurious error message.