### PR TITLE
Keep File Age Recent to Prevent Cleanup

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -109,6 +109,13 @@
             <version>0.4.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.2.22</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <developers>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.services.kinesis.producer;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
@@ -1,0 +1,60 @@
+package com.amazonaws.services.kinesis.producer;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+class FileAgeManager implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(FileAgeManager.class);
+
+    private static final FileAgeManager instance = new FileAgeManager();
+
+    static synchronized FileAgeManager instance() {
+        return instance;
+    }
+
+    private final ScheduledExecutorService executorService;
+
+    private final Set<File> watchedFiles;
+
+    FileAgeManager() {
+        this(Executors.newScheduledThreadPool(1,
+                new ThreadFactoryBuilder().setDaemon(true).setNameFormat("KP-FileMaintenance-%04d").build()));
+    }
+
+    FileAgeManager(ScheduledExecutorService executorService) {
+        this.watchedFiles = new HashSet<>();
+        this.executorService = executorService;
+        this.executorService.scheduleAtFixedRate(this, 1, 1, TimeUnit.MINUTES);
+    }
+
+    public synchronized void registerFiles(Collection<File> toRegister) {
+        for(File f : toRegister) {
+            watchedFiles.add(f.getAbsoluteFile());
+        }
+    }
+
+    @Override
+    public synchronized void run() {
+        for (File file : watchedFiles) {
+            if (!file.exists()) {
+                log.error("File '{}' doesn't exist or has been removed. "
+                        + "This could cause problems with the native components.  "
+                        + "It's recommended to restart the JVM.", file.getAbsolutePath());
+            } else {
+                if (!file.setLastModified(System.currentTimeMillis())) {
+                    log.warn("Failed to update the last modified time of '{}'.", file.getAbsolutePath());
+                }
+            }
+        }
+    }
+}

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/FileAgeManagerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/FileAgeManagerTest.java
@@ -1,0 +1,62 @@
+package com.amazonaws.services.kinesis.producer;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileAgeManagerTest {
+
+    @Mock
+    private ScheduledExecutorService executorService;
+
+    @Mock
+    private File testFile;
+
+    @Test
+    public void simpleTest() {
+        FileAgeManager manager = new FileAgeManager(executorService);
+        List<File> files = makeFileList();
+        manager.registerFiles(files);
+
+        verify(testFile).getAbsoluteFile();
+        when(testFile.exists()).thenReturn(true);
+        when(testFile.setLastModified(anyLong())).thenReturn(true);
+        manager.run();
+
+        verify(testFile).exists();
+        verify(testFile).setLastModified(anyLong());
+    }
+
+    private List<File> makeFileList() {
+        List<File> files = new ArrayList<>();
+        files.add(testFile);
+        when(testFile.getAbsoluteFile()).thenReturn(testFile);
+        return files;
+    }
+
+    @Test
+    public void missingFileTest() {
+        FileAgeManager manager = new FileAgeManager(executorService);
+        manager.registerFiles(makeFileList());
+
+        when(testFile.exists()).thenReturn(false);
+        manager.run();
+
+        verify(testFile).exists();
+        verify(testFile, never()).setLastModified(anyLong());
+
+    }
+
+}

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/FileAgeManagerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/FileAgeManagerTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.services.kinesis.producer;
 
 import java.io.File;


### PR DESCRIPTION
The Kinesis Producer Library extracts its files to a temporary
directory.  By default that is 'java.io.tmpdir', which maybe subject to
a cleanup policy.  If certain files are removed the kinesis_producer
process maybe unable to send data.

This change should keep the age of the files moving forward, and prevent
temporary cleanup scripts from removing important files.