### PR TITLE
Remove version-ranges in artifact dependencies

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -56,7 +56,7 @@
     </build>
 
     <properties>
-        <aws-sdk-core-version>(1.11.0, 1.12.0]</aws-sdk-core-version>
+        <aws-sdk-core-version>1.11.63</aws-sdk-core-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Using version ranges - eg `(1.11.0, 1.12.0]` - in your artifact dependencies leads to unreproducible builds & unwanted network traffic - please don't use them.

https://twitter.com/rtyley/status/545530331672371200
https://ceylon-lang.org/blog/2014/12/01/version-ranges/