### PR TITLE
Add Thread Pooling as a Threading Policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
-project(amazon_kinesis_producer_internal)
+project(amazon_kinesis_producer)
 
 set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_internal_SOURCE_DIR}/third_party/lib")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
-set(CMAKE_EXE_LINKER_FLAGS "-L${THIRD_PARTY_LIB_DIR} ${ADDL_LINK_CONFIG}")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     set(ADDL_LINK_CONFIG "-static-libstdc++")
     add_compile_options("-fpermissive")
 endif ()
-
-
 
 IF(CMAKE_BUILD_TYPE MATCHES DEBUG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
@@ -18,6 +14,9 @@ IF(CMAKE_BUILD_TYPE MATCHES DEBUG)
         set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
     endif (CMAKE_COMPILER_IS_GNUCXX)
 ENDIF(CMAKE_BUILD_TYPE MATCHES DEBUG)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
+set(CMAKE_EXE_LINKER_FLAGS "-L${THIRD_PARTY_LIB_DIR} ${ADDL_LINK_CONFIG}")
 
 set(SOURCE_FILES
         aws/auth/mutable_static_creds_provider.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,21 @@ project(amazon_kinesis_producer_internal)
 
 set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_internal_SOURCE_DIR}/third_party/lib")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
-if(CMAKE_COMPILER_IS_GNUCXX)
-    set(ADDL_LINK_CONFIG "-static-libstdc++")
-endif(CMAKE_COMPILER_IS_GNUCXX)
 set(CMAKE_EXE_LINKER_FLAGS "-L${THIRD_PARTY_LIB_DIR} ${ADDL_LINK_CONFIG}")
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set(ADDL_LINK_CONFIG "-static-libstdc++")
+    add_compile_options("-fpermissive")
+endif ()
+
+
+
+IF(CMAKE_BUILD_TYPE MATCHES DEBUG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
+    endif (CMAKE_COMPILER_IS_GNUCXX)
+ENDIF(CMAKE_BUILD_TYPE MATCHES DEBUG)
 
 set(SOURCE_FILES
         aws/auth/mutable_static_creds_provider.h

--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -1005,6 +1005,8 @@ class Configuration : private boost::noncopyable {
     if (c.thread_config() == ::aws::kinesis::protobuf::Configuration_ThreadConfig::Configuration_ThreadConfig_POOLED) {
       use_thread_pool(true);
       thread_pool_size(c.thread_pool_size());
+    } else if (c.thread_config() == ::aws::kinesis::protobuf::Configuration_ThreadConfig_PER_REQUEST) {
+      use_thread_pool(false);
     }
 
     for (auto i = 0; i < c.additional_metric_dims_size(); i++) {

--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -399,8 +399,8 @@ class Configuration : private boost::noncopyable {
   /// The maximum number of threads that a thread pool should be limited to.
   /// Threads are created eagerly.  This is only relevant if \see use_thread_pool() is true
   /// \return the mamximum number of threads that the thread pool should consume
-  uint32_t max_threads() const noexcept {
-    return max_threads_;
+  uint32_t thread_pool_size() const noexcept {
+    return thread_pool_size_;
   }
 
   // Enable aggregation. With aggregation, multiple user records are packed
@@ -951,9 +951,9 @@ class Configuration : private boost::noncopyable {
   /// The threads for the thread pool are allocated eagerly.
   /// \param val the maximum number of threads that the thread pool will use
   /// \return This configuration
-  Configuration& max_threads(uint32_t val) {
+  Configuration& thread_pool_size(uint32_t val) {
     if (val > 0) {
-      max_threads_ = val;
+      thread_pool_size_ = val;
     }
     return *this;
   }
@@ -1004,7 +1004,7 @@ class Configuration : private boost::noncopyable {
     verify_certificate(c.verify_certificate());
     if (c.thread_config() == ::aws::kinesis::protobuf::Configuration_ThreadConfig::Configuration_ThreadConfig_POOLED) {
       use_thread_pool(true);
-      max_threads(c.max_threads());
+      thread_pool_size(c.thread_pool_size());
     }
 
     for (auto i = 0; i < c.additional_metric_dims_size(); i++) {
@@ -1042,8 +1042,8 @@ class Configuration : private boost::noncopyable {
   uint64_t request_timeout_ = 6000;
   bool verify_certificate_ = true;
 
-  bool use_thread_pool_ = false;
-  uint32_t max_threads_ = 0;
+  bool use_thread_pool_ = true;
+  uint32_t thread_pool_size_ = 64;
 
 
   std::vector<std::tuple<std::string, std::string, std::string>>

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -105,6 +105,7 @@ make_sdk_client_cfg(const aws::kinesis::core::Configuration& kpl_cfg,
   cfg.connectTimeoutMs = cast_size_t<long>(kpl_cfg.connect_timeout());
   cfg.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(0, 0);
   if (kpl_cfg.use_thread_pool()) {
+
     if (sdk_client_executor == nullptr) {
       uint32_t thread_pool_size = kpl_cfg.thread_pool_size();
       //
@@ -113,9 +114,11 @@ make_sdk_client_cfg(const aws::kinesis::core::Configuration& kpl_cfg,
       if (thread_pool_size == 0) {
         thread_pool_size = kDefaultThreadPoolSize;
       }
+      LOG(info) << "Using pooled threading model with " << thread_pool_size << " threads.";
       sdk_client_executor = std::make_shared<Aws::Utils::Threading::PooledThreadExecutor>(thread_pool_size);
     }
   } else {
+    LOG(info) << "Using per request threading model.";
     sdk_client_executor = std::make_shared<Aws::Utils::Threading::DefaultExecutor>();
   }
   cfg.executor = sdk_client_executor;

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -105,7 +105,6 @@ make_sdk_client_cfg(const aws::kinesis::core::Configuration& kpl_cfg,
   cfg.connectTimeoutMs = cast_size_t<long>(kpl_cfg.connect_timeout());
   cfg.retryStrategy = std::make_shared<Aws::Client::DefaultRetryStrategy>(0, 0);
   if (kpl_cfg.use_thread_pool()) {
-
     if (sdk_client_executor == nullptr) {
       uint32_t thread_pool_size = kpl_cfg.thread_pool_size();
       //

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -28,6 +28,7 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* Configuration_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Configuration_reflection_ = NULL;
+const ::google::protobuf::EnumDescriptor* Configuration_ThreadConfig_descriptor_ = NULL;
 
 }  // namespace
 
@@ -56,7 +57,7 @@ void protobuf_AssignDesc_config_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AdditionalDimension));
   Configuration_descriptor_ = file->message_type(1);
-  static const int Configuration_offsets_[26] = {
+  static const int Configuration_offsets_[27] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, additional_metric_dims_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, aggregation_enabled_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, aggregation_max_count_),
@@ -83,6 +84,7 @@ void protobuf_AssignDesc_config_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, region_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, request_timeout_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, verify_certificate_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_config_),
   };
   Configuration_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -95,6 +97,7 @@ void protobuf_AssignDesc_config_2eproto() {
       ::google::protobuf::DescriptorPool::generated_pool(),
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(Configuration));
+  Configuration_ThreadConfig_descriptor_ = Configuration_descriptor_->enum_type(0);
 }
 
 namespace {
@@ -135,7 +138,7 @@ void protobuf_AddDesc_config_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
     "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\213\007\n\rConfigu"
+    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\206\010\n\rConfigu"
     "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
     ").aws.kinesis.protobuf.AdditionalDimensi"
     "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -158,7 +161,11 @@ void protobuf_AddDesc_config_2eproto() {
     "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t"
     "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req"
     "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
-    "ficate\030\031 \001(\010:\004true", 1018);
+    "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001("
+    "\01620.aws.kinesis.protobuf.Configuration.T"
+    "hreadConfig:\007DEFAULT\"\'\n\014ThreadConfig\022\013\n\007"
+    "DEFAULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.s"
+    "ervices.kinesis.producer.protobuf", 1193);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "config.proto", &protobuf_RegisterTypes);
   AdditionalDimension::default_instance_ = new AdditionalDimension();
@@ -549,6 +556,27 @@ void AdditionalDimension::Swap(AdditionalDimension* other) {
 
 // ===================================================================
 
+const ::google::protobuf::EnumDescriptor* Configuration_ThreadConfig_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return Configuration_ThreadConfig_descriptor_;
+}
+bool Configuration_ThreadConfig_IsValid(int value) {
+  switch(value) {
+    case 0:
+    case 1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#ifndef _MSC_VER
+const Configuration_ThreadConfig Configuration::DEFAULT;
+const Configuration_ThreadConfig Configuration::POOLED;
+const Configuration_ThreadConfig Configuration::ThreadConfig_MIN;
+const Configuration_ThreadConfig Configuration::ThreadConfig_MAX;
+const int Configuration::ThreadConfig_ARRAYSIZE;
+#endif  // _MSC_VER
 ::std::string* Configuration::_default_log_level_ = NULL;
 ::std::string* Configuration::_default_metrics_granularity_ = NULL;
 ::std::string* Configuration::_default_metrics_level_ = NULL;
@@ -580,6 +608,7 @@ const int Configuration::kRecordTtlFieldNumber;
 const int Configuration::kRegionFieldNumber;
 const int Configuration::kRequestTimeoutFieldNumber;
 const int Configuration::kVerifyCertificateFieldNumber;
+const int Configuration::kThreadConfigFieldNumber;
 #endif  // !_MSC_VER
 
 Configuration::Configuration()
@@ -626,6 +655,7 @@ void Configuration::SharedCtor() {
   region_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   request_timeout_ = GOOGLE_ULONGLONG(6000);
   verify_certificate_ = true;
+  thread_config_ = 0;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -748,9 +778,10 @@ void Configuration::Clear() {
       }
     }
   }
-  if (_has_bits_[24 / 32] & 50331648) {
+  if (_has_bits_[24 / 32] & 117440512) {
     request_timeout_ = GOOGLE_ULONGLONG(6000);
     verify_certificate_ = true;
+    thread_config_ = 0;
   }
 
 #undef OFFSET_OF_FIELD_
@@ -1155,6 +1186,26 @@ bool Configuration::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(208)) goto parse_thread_config;
+        break;
+      }
+
+      // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+      case 26: {
+        if (tag == 208) {
+         parse_thread_config:
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::aws::kinesis::protobuf::Configuration_ThreadConfig_IsValid(value)) {
+            set_thread_config(static_cast< ::aws::kinesis::protobuf::Configuration_ThreadConfig >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(26, value);
+          }
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectTag(1026)) goto parse_additional_metric_dims;
         break;
       }
@@ -1358,6 +1409,12 @@ void Configuration::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(25, this->verify_certificate(), output);
   }
 
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  if (has_thread_config()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      26, this->thread_config(), output);
+  }
+
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
   for (int i = 0; i < this->additional_metric_dims_size(); i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -1539,6 +1596,12 @@ void Configuration::SerializeWithCachedSizes(
   // optional bool verify_certificate = 25 [default = true];
   if (has_verify_certificate()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(25, this->verify_certificate(), target);
+  }
+
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  if (has_thread_config()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      26, this->thread_config(), target);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1733,6 +1796,12 @@ int Configuration::ByteSize() const {
       total_size += 2 + 1;
     }
 
+    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+    if (has_thread_config()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->thread_config());
+    }
+
   }
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
   total_size += 2 * this->additional_metric_dims_size();
@@ -1850,6 +1919,9 @@ void Configuration::MergeFrom(const Configuration& from) {
     if (from.has_verify_certificate()) {
       set_verify_certificate(from.verify_certificate());
     }
+    if (from.has_thread_config()) {
+      set_thread_config(from.thread_config());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1900,6 +1972,7 @@ void Configuration::Swap(Configuration* other) {
     std::swap(region_, other->region_);
     std::swap(request_timeout_, other->request_timeout_);
     std::swap(verify_certificate_, other->verify_certificate_);
+    std::swap(thread_config_, other->thread_config_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -139,7 +139,7 @@ void protobuf_AddDesc_config_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
     "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\247\010\n\rConfigu"
+    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\254\010\n\rConfigu"
     "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
     ").aws.kinesis.protobuf.AdditionalDimensi"
     "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -162,12 +162,12 @@ void protobuf_AddDesc_config_2eproto() {
     "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t"
     "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req"
     "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
-    "ficate\030\031 \001(\010:\004true\022O\n\rthread_config\030\032 \001("
+    "ficate\030\031 \001(\010:\004true\022T\n\rthread_config\030\032 \001("
     "\01620.aws.kinesis.protobuf.Configuration.T"
-    "hreadConfig:\006POOLED\022\034\n\020thread_pool_size\030"
-    "\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST"
-    "\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.services"
-    ".kinesis.producer.protobuf", 1226);
+    "hreadConfig:\013PER_REQUEST\022\034\n\020thread_pool_"
+    "size\030\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_RE"
+    "QUEST\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.ser"
+    "vices.kinesis.producer.protobuf", 1231);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "config.proto", &protobuf_RegisterTypes);
   AdditionalDimension::default_instance_ = new AdditionalDimension();
@@ -658,7 +658,7 @@ void Configuration::SharedCtor() {
   region_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   request_timeout_ = GOOGLE_ULONGLONG(6000);
   verify_certificate_ = true;
-  thread_config_ = 1;
+  thread_config_ = 0;
   thread_pool_size_ = 64u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -785,7 +785,7 @@ void Configuration::Clear() {
   if (_has_bits_[24 / 32] & 251658240) {
     request_timeout_ = GOOGLE_ULONGLONG(6000);
     verify_certificate_ = true;
-    thread_config_ = 1;
+    thread_config_ = 0;
     thread_pool_size_ = 64u;
   }
 
@@ -1195,7 +1195,7 @@ bool Configuration::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+      // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
       case 26: {
         if (tag == 208) {
          parse_thread_config:
@@ -1429,7 +1429,7 @@ void Configuration::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(25, this->verify_certificate(), output);
   }
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
   if (has_thread_config()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       26, this->thread_config(), output);
@@ -1623,7 +1623,7 @@ void Configuration::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(25, this->verify_certificate(), target);
   }
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
   if (has_thread_config()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       26, this->thread_config(), target);
@@ -1826,7 +1826,7 @@ int Configuration::ByteSize() const {
       total_size += 2 + 1;
     }
 
-    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
     if (has_thread_config()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->thread_config());

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -85,7 +85,7 @@ void protobuf_AssignDesc_config_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, request_timeout_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, verify_certificate_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_config_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_pool_max_threads_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, max_threads_),
   };
   Configuration_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -139,7 +139,7 @@ void protobuf_AddDesc_config_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
     "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\253\010\n\rConfigu"
+    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\237\010\n\rConfigu"
     "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
     ").aws.kinesis.protobuf.AdditionalDimensi"
     "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -164,10 +164,10 @@ void protobuf_AddDesc_config_2eproto() {
     "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
     "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001("
     "\01620.aws.kinesis.protobuf.Configuration.T"
-    "hreadConfig:\007DEFAULT\022#\n\027thread_pool_max_"
-    "threads\030\033 \001(\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEF"
-    "AULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.serv"
-    "ices.kinesis.producer.protobuf", 1230);
+    "hreadConfig:\007DEFAULT\022\027\n\013max_threads\030\033 \001("
+    "\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEFAULT\020\000\022\n\n\006PO"
+    "OLED\020\001B2\n0com.amazonaws.services.kinesis"
+    ".producer.protobuf", 1218);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "config.proto", &protobuf_RegisterTypes);
   AdditionalDimension::default_instance_ = new AdditionalDimension();
@@ -611,7 +611,7 @@ const int Configuration::kRegionFieldNumber;
 const int Configuration::kRequestTimeoutFieldNumber;
 const int Configuration::kVerifyCertificateFieldNumber;
 const int Configuration::kThreadConfigFieldNumber;
-const int Configuration::kThreadPoolMaxThreadsFieldNumber;
+const int Configuration::kMaxThreadsFieldNumber;
 #endif  // !_MSC_VER
 
 Configuration::Configuration()
@@ -659,7 +659,7 @@ void Configuration::SharedCtor() {
   request_timeout_ = GOOGLE_ULONGLONG(6000);
   verify_certificate_ = true;
   thread_config_ = 0;
-  thread_pool_max_threads_ = 32u;
+  max_threads_ = 32u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -786,7 +786,7 @@ void Configuration::Clear() {
     request_timeout_ = GOOGLE_ULONGLONG(6000);
     verify_certificate_ = true;
     thread_config_ = 0;
-    thread_pool_max_threads_ = 32u;
+    max_threads_ = 32u;
   }
 
 #undef OFFSET_OF_FIELD_
@@ -1211,18 +1211,18 @@ bool Configuration::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(216)) goto parse_thread_pool_max_threads;
+        if (input->ExpectTag(216)) goto parse_max_threads;
         break;
       }
 
-      // optional uint32 thread_pool_max_threads = 27 [default = 32];
+      // optional uint32 max_threads = 27 [default = 32];
       case 27: {
         if (tag == 216) {
-         parse_thread_pool_max_threads:
+         parse_max_threads:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &thread_pool_max_threads_)));
-          set_has_thread_pool_max_threads();
+                 input, &max_threads_)));
+          set_has_max_threads();
         } else {
           goto handle_unusual;
         }
@@ -1435,9 +1435,9 @@ void Configuration::SerializeWithCachedSizes(
       26, this->thread_config(), output);
   }
 
-  // optional uint32 thread_pool_max_threads = 27 [default = 32];
-  if (has_thread_pool_max_threads()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(27, this->thread_pool_max_threads(), output);
+  // optional uint32 max_threads = 27 [default = 32];
+  if (has_max_threads()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(27, this->max_threads(), output);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1629,9 +1629,9 @@ void Configuration::SerializeWithCachedSizes(
       26, this->thread_config(), target);
   }
 
-  // optional uint32 thread_pool_max_threads = 27 [default = 32];
-  if (has_thread_pool_max_threads()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(27, this->thread_pool_max_threads(), target);
+  // optional uint32 max_threads = 27 [default = 32];
+  if (has_max_threads()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(27, this->max_threads(), target);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1832,11 +1832,11 @@ int Configuration::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->thread_config());
     }
 
-    // optional uint32 thread_pool_max_threads = 27 [default = 32];
-    if (has_thread_pool_max_threads()) {
+    // optional uint32 max_threads = 27 [default = 32];
+    if (has_max_threads()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->thread_pool_max_threads());
+          this->max_threads());
     }
 
   }
@@ -1959,8 +1959,8 @@ void Configuration::MergeFrom(const Configuration& from) {
     if (from.has_thread_config()) {
       set_thread_config(from.thread_config());
     }
-    if (from.has_thread_pool_max_threads()) {
-      set_thread_pool_max_threads(from.thread_pool_max_threads());
+    if (from.has_max_threads()) {
+      set_max_threads(from.max_threads());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -2013,7 +2013,7 @@ void Configuration::Swap(Configuration* other) {
     std::swap(request_timeout_, other->request_timeout_);
     std::swap(verify_certificate_, other->verify_certificate_);
     std::swap(thread_config_, other->thread_config_);
-    std::swap(thread_pool_max_threads_, other->thread_pool_max_threads_);
+    std::swap(max_threads_, other->max_threads_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -85,7 +85,7 @@ void protobuf_AssignDesc_config_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, request_timeout_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, verify_certificate_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_config_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, max_threads_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_pool_size_),
   };
   Configuration_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -139,7 +139,7 @@ void protobuf_AddDesc_config_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
     "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\237\010\n\rConfigu"
+    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\247\010\n\rConfigu"
     "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
     ").aws.kinesis.protobuf.AdditionalDimensi"
     "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -162,12 +162,12 @@ void protobuf_AddDesc_config_2eproto() {
     "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t"
     "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req"
     "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
-    "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001("
+    "ficate\030\031 \001(\010:\004true\022O\n\rthread_config\030\032 \001("
     "\01620.aws.kinesis.protobuf.Configuration.T"
-    "hreadConfig:\007DEFAULT\022\027\n\013max_threads\030\033 \001("
-    "\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEFAULT\020\000\022\n\n\006PO"
-    "OLED\020\001B2\n0com.amazonaws.services.kinesis"
-    ".producer.protobuf", 1218);
+    "hreadConfig:\006POOLED\022\034\n\020thread_pool_size\030"
+    "\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST"
+    "\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.services"
+    ".kinesis.producer.protobuf", 1226);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "config.proto", &protobuf_RegisterTypes);
   AdditionalDimension::default_instance_ = new AdditionalDimension();
@@ -573,7 +573,7 @@ bool Configuration_ThreadConfig_IsValid(int value) {
 }
 
 #ifndef _MSC_VER
-const Configuration_ThreadConfig Configuration::DEFAULT;
+const Configuration_ThreadConfig Configuration::PER_REQUEST;
 const Configuration_ThreadConfig Configuration::POOLED;
 const Configuration_ThreadConfig Configuration::ThreadConfig_MIN;
 const Configuration_ThreadConfig Configuration::ThreadConfig_MAX;
@@ -611,7 +611,7 @@ const int Configuration::kRegionFieldNumber;
 const int Configuration::kRequestTimeoutFieldNumber;
 const int Configuration::kVerifyCertificateFieldNumber;
 const int Configuration::kThreadConfigFieldNumber;
-const int Configuration::kMaxThreadsFieldNumber;
+const int Configuration::kThreadPoolSizeFieldNumber;
 #endif  // !_MSC_VER
 
 Configuration::Configuration()
@@ -658,8 +658,8 @@ void Configuration::SharedCtor() {
   region_ = const_cast< ::std::string*>(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   request_timeout_ = GOOGLE_ULONGLONG(6000);
   verify_certificate_ = true;
-  thread_config_ = 0;
-  max_threads_ = 32u;
+  thread_config_ = 1;
+  thread_pool_size_ = 64u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -785,8 +785,8 @@ void Configuration::Clear() {
   if (_has_bits_[24 / 32] & 251658240) {
     request_timeout_ = GOOGLE_ULONGLONG(6000);
     verify_certificate_ = true;
-    thread_config_ = 0;
-    max_threads_ = 32u;
+    thread_config_ = 1;
+    thread_pool_size_ = 64u;
   }
 
 #undef OFFSET_OF_FIELD_
@@ -1195,7 +1195,7 @@ bool Configuration::MergePartialFromCodedStream(
         break;
       }
 
-      // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+      // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
       case 26: {
         if (tag == 208) {
          parse_thread_config:
@@ -1211,18 +1211,18 @@ bool Configuration::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(216)) goto parse_max_threads;
+        if (input->ExpectTag(216)) goto parse_thread_pool_size;
         break;
       }
 
-      // optional uint32 max_threads = 27 [default = 32];
+      // optional uint32 thread_pool_size = 27 [default = 64];
       case 27: {
         if (tag == 216) {
-         parse_max_threads:
+         parse_thread_pool_size:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &max_threads_)));
-          set_has_max_threads();
+                 input, &thread_pool_size_)));
+          set_has_thread_pool_size();
         } else {
           goto handle_unusual;
         }
@@ -1429,15 +1429,15 @@ void Configuration::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(25, this->verify_certificate(), output);
   }
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
   if (has_thread_config()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       26, this->thread_config(), output);
   }
 
-  // optional uint32 max_threads = 27 [default = 32];
-  if (has_max_threads()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(27, this->max_threads(), output);
+  // optional uint32 thread_pool_size = 27 [default = 64];
+  if (has_thread_pool_size()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(27, this->thread_pool_size(), output);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1623,15 +1623,15 @@ void Configuration::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(25, this->verify_certificate(), target);
   }
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
   if (has_thread_config()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       26, this->thread_config(), target);
   }
 
-  // optional uint32 max_threads = 27 [default = 32];
-  if (has_max_threads()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(27, this->max_threads(), target);
+  // optional uint32 thread_pool_size = 27 [default = 64];
+  if (has_thread_pool_size()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(27, this->thread_pool_size(), target);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1826,17 +1826,17 @@ int Configuration::ByteSize() const {
       total_size += 2 + 1;
     }
 
-    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
     if (has_thread_config()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->thread_config());
     }
 
-    // optional uint32 max_threads = 27 [default = 32];
-    if (has_max_threads()) {
+    // optional uint32 thread_pool_size = 27 [default = 64];
+    if (has_thread_pool_size()) {
       total_size += 2 +
         ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->max_threads());
+          this->thread_pool_size());
     }
 
   }
@@ -1959,8 +1959,8 @@ void Configuration::MergeFrom(const Configuration& from) {
     if (from.has_thread_config()) {
       set_thread_config(from.thread_config());
     }
-    if (from.has_max_threads()) {
-      set_max_threads(from.max_threads());
+    if (from.has_thread_pool_size()) {
+      set_thread_pool_size(from.thread_pool_size());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -2013,7 +2013,7 @@ void Configuration::Swap(Configuration* other) {
     std::swap(request_timeout_, other->request_timeout_);
     std::swap(verify_certificate_, other->verify_certificate_);
     std::swap(thread_config_, other->thread_config_);
-    std::swap(max_threads_, other->max_threads_);
+    std::swap(thread_pool_size_, other->thread_pool_size_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -57,7 +57,7 @@ void protobuf_AssignDesc_config_2eproto() {
       ::google::protobuf::MessageFactory::generated_factory(),
       sizeof(AdditionalDimension));
   Configuration_descriptor_ = file->message_type(1);
-  static const int Configuration_offsets_[27] = {
+  static const int Configuration_offsets_[28] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, additional_metric_dims_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, aggregation_enabled_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, aggregation_max_count_),
@@ -85,6 +85,7 @@ void protobuf_AssignDesc_config_2eproto() {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, request_timeout_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, verify_certificate_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_config_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Configuration, thread_pool_max_threads_),
   };
   Configuration_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -138,7 +139,7 @@ void protobuf_AddDesc_config_2eproto() {
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
     "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
     "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\206\010\n\rConfigu"
+    "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\253\010\n\rConfigu"
     "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
     ").aws.kinesis.protobuf.AdditionalDimensi"
     "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -163,9 +164,10 @@ void protobuf_AddDesc_config_2eproto() {
     "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
     "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001("
     "\01620.aws.kinesis.protobuf.Configuration.T"
-    "hreadConfig:\007DEFAULT\"\'\n\014ThreadConfig\022\013\n\007"
-    "DEFAULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.s"
-    "ervices.kinesis.producer.protobuf", 1193);
+    "hreadConfig:\007DEFAULT\022#\n\027thread_pool_max_"
+    "threads\030\033 \001(\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEF"
+    "AULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.serv"
+    "ices.kinesis.producer.protobuf", 1230);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "config.proto", &protobuf_RegisterTypes);
   AdditionalDimension::default_instance_ = new AdditionalDimension();
@@ -609,6 +611,7 @@ const int Configuration::kRegionFieldNumber;
 const int Configuration::kRequestTimeoutFieldNumber;
 const int Configuration::kVerifyCertificateFieldNumber;
 const int Configuration::kThreadConfigFieldNumber;
+const int Configuration::kThreadPoolMaxThreadsFieldNumber;
 #endif  // !_MSC_VER
 
 Configuration::Configuration()
@@ -656,6 +659,7 @@ void Configuration::SharedCtor() {
   request_timeout_ = GOOGLE_ULONGLONG(6000);
   verify_certificate_ = true;
   thread_config_ = 0;
+  thread_pool_max_threads_ = 32u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -778,10 +782,11 @@ void Configuration::Clear() {
       }
     }
   }
-  if (_has_bits_[24 / 32] & 117440512) {
+  if (_has_bits_[24 / 32] & 251658240) {
     request_timeout_ = GOOGLE_ULONGLONG(6000);
     verify_certificate_ = true;
     thread_config_ = 0;
+    thread_pool_max_threads_ = 32u;
   }
 
 #undef OFFSET_OF_FIELD_
@@ -1206,6 +1211,21 @@ bool Configuration::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
+        if (input->ExpectTag(216)) goto parse_thread_pool_max_threads;
+        break;
+      }
+
+      // optional uint32 thread_pool_max_threads = 27 [default = 32];
+      case 27: {
+        if (tag == 216) {
+         parse_thread_pool_max_threads:
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
+                 input, &thread_pool_max_threads_)));
+          set_has_thread_pool_max_threads();
+        } else {
+          goto handle_unusual;
+        }
         if (input->ExpectTag(1026)) goto parse_additional_metric_dims;
         break;
       }
@@ -1415,6 +1435,11 @@ void Configuration::SerializeWithCachedSizes(
       26, this->thread_config(), output);
   }
 
+  // optional uint32 thread_pool_max_threads = 27 [default = 32];
+  if (has_thread_pool_max_threads()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(27, this->thread_pool_max_threads(), output);
+  }
+
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
   for (int i = 0; i < this->additional_metric_dims_size(); i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -1602,6 +1627,11 @@ void Configuration::SerializeWithCachedSizes(
   if (has_thread_config()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       26, this->thread_config(), target);
+  }
+
+  // optional uint32 thread_pool_max_threads = 27 [default = 32];
+  if (has_thread_pool_max_threads()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteUInt32ToArray(27, this->thread_pool_max_threads(), target);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1802,6 +1832,13 @@ int Configuration::ByteSize() const {
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->thread_config());
     }
 
+    // optional uint32 thread_pool_max_threads = 27 [default = 32];
+    if (has_thread_pool_max_threads()) {
+      total_size += 2 +
+        ::google::protobuf::internal::WireFormatLite::UInt32Size(
+          this->thread_pool_max_threads());
+    }
+
   }
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
   total_size += 2 * this->additional_metric_dims_size();
@@ -1922,6 +1959,9 @@ void Configuration::MergeFrom(const Configuration& from) {
     if (from.has_thread_config()) {
       set_thread_config(from.thread_config());
     }
+    if (from.has_thread_pool_max_threads()) {
+      set_thread_pool_max_threads(from.thread_pool_max_threads());
+    }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
 }
@@ -1973,6 +2013,7 @@ void Configuration::Swap(Configuration* other) {
     std::swap(request_timeout_, other->request_timeout_);
     std::swap(verify_certificate_, other->verify_certificate_);
     std::swap(thread_config_, other->thread_config_);
+    std::swap(thread_pool_max_threads_, other->thread_pool_max_threads_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -473,7 +473,7 @@ class Configuration : public ::google::protobuf::Message {
   inline bool verify_certificate() const;
   inline void set_verify_certificate(bool value);
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
   inline bool has_thread_config() const;
   inline void clear_thread_config();
   static const int kThreadConfigFieldNumber = 26;
@@ -1820,7 +1820,7 @@ inline void Configuration::set_verify_certificate(bool value) {
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.verify_certificate)
 }
 
-// optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
+// optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];
 inline bool Configuration::has_thread_config() const {
   return (_has_bits_[0] & 0x04000000u) != 0;
 }
@@ -1831,7 +1831,7 @@ inline void Configuration::clear_has_thread_config() {
   _has_bits_[0] &= ~0x04000000u;
 }
 inline void Configuration::clear_thread_config() {
-  thread_config_ = 1;
+  thread_config_ = 0;
   clear_has_thread_config();
 }
 inline ::aws::kinesis::protobuf::Configuration_ThreadConfig Configuration::thread_config() const {

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -480,12 +480,12 @@ class Configuration : public ::google::protobuf::Message {
   inline ::aws::kinesis::protobuf::Configuration_ThreadConfig thread_config() const;
   inline void set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value);
 
-  // optional uint32 thread_pool_max_threads = 27 [default = 32];
-  inline bool has_thread_pool_max_threads() const;
-  inline void clear_thread_pool_max_threads();
-  static const int kThreadPoolMaxThreadsFieldNumber = 27;
-  inline ::google::protobuf::uint32 thread_pool_max_threads() const;
-  inline void set_thread_pool_max_threads(::google::protobuf::uint32 value);
+  // optional uint32 max_threads = 27 [default = 32];
+  inline bool has_max_threads() const;
+  inline void clear_max_threads();
+  static const int kMaxThreadsFieldNumber = 27;
+  inline ::google::protobuf::uint32 max_threads() const;
+  inline void set_max_threads(::google::protobuf::uint32 value);
 
   // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
  private:
@@ -541,8 +541,8 @@ class Configuration : public ::google::protobuf::Message {
   inline void clear_has_verify_certificate();
   inline void set_has_thread_config();
   inline void clear_has_thread_config();
-  inline void set_has_thread_pool_max_threads();
-  inline void clear_has_thread_pool_max_threads();
+  inline void set_has_max_threads();
+  inline void clear_has_max_threads();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -579,7 +579,7 @@ class Configuration : public ::google::protobuf::Message {
   ::google::protobuf::uint64 record_ttl_;
   ::std::string* region_;
   ::google::protobuf::uint64 request_timeout_;
-  ::google::protobuf::uint32 thread_pool_max_threads_;
+  ::google::protobuf::uint32 max_threads_;
   friend void  protobuf_AddDesc_config_2eproto();
   friend void protobuf_AssignDesc_config_2eproto();
   friend void protobuf_ShutdownFile_config_2eproto();
@@ -1845,28 +1845,28 @@ inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configura
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_config)
 }
 
-// optional uint32 thread_pool_max_threads = 27 [default = 32];
-inline bool Configuration::has_thread_pool_max_threads() const {
+// optional uint32 max_threads = 27 [default = 32];
+inline bool Configuration::has_max_threads() const {
   return (_has_bits_[0] & 0x08000000u) != 0;
 }
-inline void Configuration::set_has_thread_pool_max_threads() {
+inline void Configuration::set_has_max_threads() {
   _has_bits_[0] |= 0x08000000u;
 }
-inline void Configuration::clear_has_thread_pool_max_threads() {
+inline void Configuration::clear_has_max_threads() {
   _has_bits_[0] &= ~0x08000000u;
 }
-inline void Configuration::clear_thread_pool_max_threads() {
-  thread_pool_max_threads_ = 32u;
-  clear_has_thread_pool_max_threads();
+inline void Configuration::clear_max_threads() {
+  max_threads_ = 32u;
+  clear_has_max_threads();
 }
-inline ::google::protobuf::uint32 Configuration::thread_pool_max_threads() const {
-  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.thread_pool_max_threads)
-  return thread_pool_max_threads_;
+inline ::google::protobuf::uint32 Configuration::max_threads() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.max_threads)
+  return max_threads_;
 }
-inline void Configuration::set_thread_pool_max_threads(::google::protobuf::uint32 value) {
-  set_has_thread_pool_max_threads();
-  thread_pool_max_threads_ = value;
-  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_pool_max_threads)
+inline void Configuration::set_max_threads(::google::protobuf::uint32 value) {
+  set_has_max_threads();
+  max_threads_ = value;
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.max_threads)
 }
 
 

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -40,11 +40,11 @@ class AdditionalDimension;
 class Configuration;
 
 enum Configuration_ThreadConfig {
-  Configuration_ThreadConfig_DEFAULT = 0,
+  Configuration_ThreadConfig_PER_REQUEST = 0,
   Configuration_ThreadConfig_POOLED = 1
 };
 bool Configuration_ThreadConfig_IsValid(int value);
-const Configuration_ThreadConfig Configuration_ThreadConfig_ThreadConfig_MIN = Configuration_ThreadConfig_DEFAULT;
+const Configuration_ThreadConfig Configuration_ThreadConfig_ThreadConfig_MIN = Configuration_ThreadConfig_PER_REQUEST;
 const Configuration_ThreadConfig Configuration_ThreadConfig_ThreadConfig_MAX = Configuration_ThreadConfig_POOLED;
 const int Configuration_ThreadConfig_ThreadConfig_ARRAYSIZE = Configuration_ThreadConfig_ThreadConfig_MAX + 1;
 
@@ -226,7 +226,7 @@ class Configuration : public ::google::protobuf::Message {
   // nested types ----------------------------------------------------
 
   typedef Configuration_ThreadConfig ThreadConfig;
-  static const ThreadConfig DEFAULT = Configuration_ThreadConfig_DEFAULT;
+  static const ThreadConfig PER_REQUEST = Configuration_ThreadConfig_PER_REQUEST;
   static const ThreadConfig POOLED = Configuration_ThreadConfig_POOLED;
   static inline bool ThreadConfig_IsValid(int value) {
     return Configuration_ThreadConfig_IsValid(value);
@@ -473,19 +473,19 @@ class Configuration : public ::google::protobuf::Message {
   inline bool verify_certificate() const;
   inline void set_verify_certificate(bool value);
 
-  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
   inline bool has_thread_config() const;
   inline void clear_thread_config();
   static const int kThreadConfigFieldNumber = 26;
   inline ::aws::kinesis::protobuf::Configuration_ThreadConfig thread_config() const;
   inline void set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value);
 
-  // optional uint32 max_threads = 27 [default = 32];
-  inline bool has_max_threads() const;
-  inline void clear_max_threads();
-  static const int kMaxThreadsFieldNumber = 27;
-  inline ::google::protobuf::uint32 max_threads() const;
-  inline void set_max_threads(::google::protobuf::uint32 value);
+  // optional uint32 thread_pool_size = 27 [default = 64];
+  inline bool has_thread_pool_size() const;
+  inline void clear_thread_pool_size();
+  static const int kThreadPoolSizeFieldNumber = 27;
+  inline ::google::protobuf::uint32 thread_pool_size() const;
+  inline void set_thread_pool_size(::google::protobuf::uint32 value);
 
   // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
  private:
@@ -541,8 +541,8 @@ class Configuration : public ::google::protobuf::Message {
   inline void clear_has_verify_certificate();
   inline void set_has_thread_config();
   inline void clear_has_thread_config();
-  inline void set_has_max_threads();
-  inline void clear_has_max_threads();
+  inline void set_has_thread_pool_size();
+  inline void clear_has_thread_pool_size();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -579,7 +579,7 @@ class Configuration : public ::google::protobuf::Message {
   ::google::protobuf::uint64 record_ttl_;
   ::std::string* region_;
   ::google::protobuf::uint64 request_timeout_;
-  ::google::protobuf::uint32 max_threads_;
+  ::google::protobuf::uint32 thread_pool_size_;
   friend void  protobuf_AddDesc_config_2eproto();
   friend void protobuf_AssignDesc_config_2eproto();
   friend void protobuf_ShutdownFile_config_2eproto();
@@ -1820,7 +1820,7 @@ inline void Configuration::set_verify_certificate(bool value) {
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.verify_certificate)
 }
 
-// optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+// optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];
 inline bool Configuration::has_thread_config() const {
   return (_has_bits_[0] & 0x04000000u) != 0;
 }
@@ -1831,7 +1831,7 @@ inline void Configuration::clear_has_thread_config() {
   _has_bits_[0] &= ~0x04000000u;
 }
 inline void Configuration::clear_thread_config() {
-  thread_config_ = 0;
+  thread_config_ = 1;
   clear_has_thread_config();
 }
 inline ::aws::kinesis::protobuf::Configuration_ThreadConfig Configuration::thread_config() const {
@@ -1845,28 +1845,28 @@ inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configura
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_config)
 }
 
-// optional uint32 max_threads = 27 [default = 32];
-inline bool Configuration::has_max_threads() const {
+// optional uint32 thread_pool_size = 27 [default = 64];
+inline bool Configuration::has_thread_pool_size() const {
   return (_has_bits_[0] & 0x08000000u) != 0;
 }
-inline void Configuration::set_has_max_threads() {
+inline void Configuration::set_has_thread_pool_size() {
   _has_bits_[0] |= 0x08000000u;
 }
-inline void Configuration::clear_has_max_threads() {
+inline void Configuration::clear_has_thread_pool_size() {
   _has_bits_[0] &= ~0x08000000u;
 }
-inline void Configuration::clear_max_threads() {
-  max_threads_ = 32u;
-  clear_has_max_threads();
+inline void Configuration::clear_thread_pool_size() {
+  thread_pool_size_ = 64u;
+  clear_has_thread_pool_size();
 }
-inline ::google::protobuf::uint32 Configuration::max_threads() const {
-  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.max_threads)
-  return max_threads_;
+inline ::google::protobuf::uint32 Configuration::thread_pool_size() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.thread_pool_size)
+  return thread_pool_size_;
 }
-inline void Configuration::set_max_threads(::google::protobuf::uint32 value) {
-  set_has_max_threads();
-  max_threads_ = value;
-  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.max_threads)
+inline void Configuration::set_thread_pool_size(::google::protobuf::uint32 value) {
+  set_has_thread_pool_size();
+  thread_pool_size_ = value;
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_pool_size)
 }
 
 

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -23,6 +23,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/extension_set.h>
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 // @@protoc_insertion_point(includes)
 
@@ -38,6 +39,25 @@ void protobuf_ShutdownFile_config_2eproto();
 class AdditionalDimension;
 class Configuration;
 
+enum Configuration_ThreadConfig {
+  Configuration_ThreadConfig_DEFAULT = 0,
+  Configuration_ThreadConfig_POOLED = 1
+};
+bool Configuration_ThreadConfig_IsValid(int value);
+const Configuration_ThreadConfig Configuration_ThreadConfig_ThreadConfig_MIN = Configuration_ThreadConfig_DEFAULT;
+const Configuration_ThreadConfig Configuration_ThreadConfig_ThreadConfig_MAX = Configuration_ThreadConfig_POOLED;
+const int Configuration_ThreadConfig_ThreadConfig_ARRAYSIZE = Configuration_ThreadConfig_ThreadConfig_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* Configuration_ThreadConfig_descriptor();
+inline const ::std::string& Configuration_ThreadConfig_Name(Configuration_ThreadConfig value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    Configuration_ThreadConfig_descriptor(), value);
+}
+inline bool Configuration_ThreadConfig_Parse(
+    const ::std::string& name, Configuration_ThreadConfig* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<Configuration_ThreadConfig>(
+    Configuration_ThreadConfig_descriptor(), name, value);
+}
 // ===================================================================
 
 class AdditionalDimension : public ::google::protobuf::Message {
@@ -204,6 +224,30 @@ class Configuration : public ::google::protobuf::Message {
   ::google::protobuf::Metadata GetMetadata() const;
 
   // nested types ----------------------------------------------------
+
+  typedef Configuration_ThreadConfig ThreadConfig;
+  static const ThreadConfig DEFAULT = Configuration_ThreadConfig_DEFAULT;
+  static const ThreadConfig POOLED = Configuration_ThreadConfig_POOLED;
+  static inline bool ThreadConfig_IsValid(int value) {
+    return Configuration_ThreadConfig_IsValid(value);
+  }
+  static const ThreadConfig ThreadConfig_MIN =
+    Configuration_ThreadConfig_ThreadConfig_MIN;
+  static const ThreadConfig ThreadConfig_MAX =
+    Configuration_ThreadConfig_ThreadConfig_MAX;
+  static const int ThreadConfig_ARRAYSIZE =
+    Configuration_ThreadConfig_ThreadConfig_ARRAYSIZE;
+  static inline const ::google::protobuf::EnumDescriptor*
+  ThreadConfig_descriptor() {
+    return Configuration_ThreadConfig_descriptor();
+  }
+  static inline const ::std::string& ThreadConfig_Name(ThreadConfig value) {
+    return Configuration_ThreadConfig_Name(value);
+  }
+  static inline bool ThreadConfig_Parse(const ::std::string& name,
+      ThreadConfig* value) {
+    return Configuration_ThreadConfig_Parse(name, value);
+  }
 
   // accessors -------------------------------------------------------
 
@@ -429,6 +473,13 @@ class Configuration : public ::google::protobuf::Message {
   inline bool verify_certificate() const;
   inline void set_verify_certificate(bool value);
 
+  // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+  inline bool has_thread_config() const;
+  inline void clear_thread_config();
+  static const int kThreadConfigFieldNumber = 26;
+  inline ::aws::kinesis::protobuf::Configuration_ThreadConfig thread_config() const;
+  inline void set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value);
+
   // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
  private:
   inline void set_has_aggregation_enabled();
@@ -481,6 +532,8 @@ class Configuration : public ::google::protobuf::Message {
   inline void clear_has_request_timeout();
   inline void set_has_verify_certificate();
   inline void clear_has_verify_certificate();
+  inline void set_has_thread_config();
+  inline void clear_has_thread_config();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -499,6 +552,11 @@ class Configuration : public ::google::protobuf::Message {
   static ::std::string* _default_log_level_;
   ::std::string* log_level_;
   ::google::protobuf::uint64 max_connections_;
+  bool aggregation_enabled_;
+  bool enable_core_dumps_;
+  bool fail_if_throttled_;
+  bool verify_certificate_;
+  int thread_config_;
   static ::std::string* _default_metrics_granularity_;
   ::std::string* metrics_granularity_;
   static ::std::string* _default_metrics_level_;
@@ -512,10 +570,6 @@ class Configuration : public ::google::protobuf::Message {
   ::google::protobuf::uint64 record_ttl_;
   ::std::string* region_;
   ::google::protobuf::uint64 request_timeout_;
-  bool aggregation_enabled_;
-  bool enable_core_dumps_;
-  bool fail_if_throttled_;
-  bool verify_certificate_;
   friend void  protobuf_AddDesc_config_2eproto();
   friend void protobuf_AssignDesc_config_2eproto();
   friend void protobuf_ShutdownFile_config_2eproto();
@@ -1756,6 +1810,31 @@ inline void Configuration::set_verify_certificate(bool value) {
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.verify_certificate)
 }
 
+// optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];
+inline bool Configuration::has_thread_config() const {
+  return (_has_bits_[0] & 0x04000000u) != 0;
+}
+inline void Configuration::set_has_thread_config() {
+  _has_bits_[0] |= 0x04000000u;
+}
+inline void Configuration::clear_has_thread_config() {
+  _has_bits_[0] &= ~0x04000000u;
+}
+inline void Configuration::clear_thread_config() {
+  thread_config_ = 0;
+  clear_has_thread_config();
+}
+inline ::aws::kinesis::protobuf::Configuration_ThreadConfig Configuration::thread_config() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.thread_config)
+  return static_cast< ::aws::kinesis::protobuf::Configuration_ThreadConfig >(thread_config_);
+}
+inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value) {
+  assert(::aws::kinesis::protobuf::Configuration_ThreadConfig_IsValid(value));
+  set_has_thread_config();
+  thread_config_ = value;
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_config)
+}
+
 
 // @@protoc_insertion_point(namespace_scope)
 
@@ -1767,6 +1846,11 @@ inline void Configuration::set_verify_certificate(bool value) {
 namespace google {
 namespace protobuf {
 
+template <> struct is_proto_enum< ::aws::kinesis::protobuf::Configuration_ThreadConfig> : ::google::protobuf::internal::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::aws::kinesis::protobuf::Configuration_ThreadConfig>() {
+  return ::aws::kinesis::protobuf::Configuration_ThreadConfig_descriptor();
+}
 
 }  // namespace google
 }  // namespace protobuf

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -480,6 +480,13 @@ class Configuration : public ::google::protobuf::Message {
   inline ::aws::kinesis::protobuf::Configuration_ThreadConfig thread_config() const;
   inline void set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value);
 
+  // optional uint32 thread_pool_max_threads = 27 [default = 32];
+  inline bool has_thread_pool_max_threads() const;
+  inline void clear_thread_pool_max_threads();
+  static const int kThreadPoolMaxThreadsFieldNumber = 27;
+  inline ::google::protobuf::uint32 thread_pool_max_threads() const;
+  inline void set_thread_pool_max_threads(::google::protobuf::uint32 value);
+
   // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
  private:
   inline void set_has_aggregation_enabled();
@@ -534,6 +541,8 @@ class Configuration : public ::google::protobuf::Message {
   inline void clear_has_verify_certificate();
   inline void set_has_thread_config();
   inline void clear_has_thread_config();
+  inline void set_has_thread_pool_max_threads();
+  inline void clear_has_thread_pool_max_threads();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
@@ -570,6 +579,7 @@ class Configuration : public ::google::protobuf::Message {
   ::google::protobuf::uint64 record_ttl_;
   ::std::string* region_;
   ::google::protobuf::uint64 request_timeout_;
+  ::google::protobuf::uint32 thread_pool_max_threads_;
   friend void  protobuf_AddDesc_config_2eproto();
   friend void protobuf_AssignDesc_config_2eproto();
   friend void protobuf_ShutdownFile_config_2eproto();
@@ -1833,6 +1843,30 @@ inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configura
   set_has_thread_config();
   thread_config_ = value;
   // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_config)
+}
+
+// optional uint32 thread_pool_max_threads = 27 [default = 32];
+inline bool Configuration::has_thread_pool_max_threads() const {
+  return (_has_bits_[0] & 0x08000000u) != 0;
+}
+inline void Configuration::set_has_thread_pool_max_threads() {
+  _has_bits_[0] |= 0x08000000u;
+}
+inline void Configuration::clear_has_thread_pool_max_threads() {
+  _has_bits_[0] &= ~0x08000000u;
+}
+inline void Configuration::clear_thread_pool_max_threads() {
+  thread_pool_max_threads_ = 32u;
+  clear_has_thread_pool_max_threads();
+}
+inline ::google::protobuf::uint32 Configuration::thread_pool_max_threads() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.thread_pool_max_threads)
+  return thread_pool_max_threads_;
+}
+inline void Configuration::set_thread_pool_max_threads(::google::protobuf::uint32 value) {
+  set_has_thread_pool_max_threads();
+  thread_pool_max_threads_ = value;
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.thread_pool_max_threads)
 }
 
 

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -42,4 +42,5 @@ message Configuration {
     POOLED = 1;
   }
   optional ThreadConfig thread_config = 26 [default = DEFAULT];
+  optional uint32 thread_pool_max_threads = 27 [default = 32];
 }

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -38,9 +38,9 @@ message Configuration {
   optional uint64 request_timeout = 24 [default = 6000];
   optional bool verify_certificate = 25 [default = true];
   enum ThreadConfig {
-    DEFAULT = 0;
+    PER_REQUEST = 0;
     POOLED = 1;
   }
-  optional ThreadConfig thread_config = 26 [default = DEFAULT];
-  optional uint32 max_threads = 27 [default = 32];
+  optional ThreadConfig thread_config = 26 [default = POOLED];
+  optional uint32 thread_pool_size = 27 [default = 64];
 }

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -42,5 +42,5 @@ message Configuration {
     POOLED = 1;
   }
   optional ThreadConfig thread_config = 26 [default = DEFAULT];
-  optional uint32 thread_pool_max_threads = 27 [default = 32];
+  optional uint32 max_threads = 27 [default = 32];
 }

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -41,6 +41,6 @@ message Configuration {
     PER_REQUEST = 0;
     POOLED = 1;
   }
-  optional ThreadConfig thread_config = 26 [default = POOLED];
+  optional ThreadConfig thread_config = 26 [default = PER_REQUEST];
   optional uint32 thread_pool_size = 27 [default = 64];
 }

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -1,5 +1,7 @@
-
+syntax = "proto2";
 package aws.kinesis.protobuf;
+
+option java_package = "com.amazonaws.services.kinesis.producer.protobuf";
 
 message AdditionalDimension {
   required string key         = 1;
@@ -35,4 +37,9 @@ message Configuration {
   optional string region = 23 [default = ""];
   optional uint64 request_timeout = 24 [default = 6000];
   optional bool verify_certificate = 25 [default = true];
+  enum ThreadConfig {
+    DEFAULT = 0;
+    POOLED = 1;
+  }
+  optional ThreadConfig thread_config = 26 [default = DEFAULT];
 }

--- a/aws/mutex.h
+++ b/aws/mutex.h
@@ -19,6 +19,7 @@
 #if BOOST_OS_WINDOWS == 0
   #include <shared_mutex>
   #include <condition_variable>
+  #include <mutex>
   #include <thread>
 #endif
 

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -43,6 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.3</version>
+    <version>0.12.4-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.xml.bind.DatatypeConverter;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -428,6 +429,8 @@ public class Daemon {
         }
         args.add("-w");
         args.add(protobufToHex(makeSetCredentialsMessage(metricsCreds, true)));
+
+        log.debug("Starting Native Process: {}", StringUtils.join(args, " "));
 
         final ProcessBuilder pb = new ProcessBuilder(args);
         for (Entry<String, String> e : environmentVariables.entrySet()) {

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -1393,9 +1393,6 @@ public class KinesisProducerConfiguration {
         }
 
         Configuration c = this.additionalConfigsToProtobuf(builder).build();
-       return Message.newBuilder()
-                      .setConfiguration(c)
-                      .setId(0)
-                      .build();
+        return Message.newBuilder().setConfiguration(c).setId(0).build();
     }
 }

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -269,7 +269,7 @@ public class KinesisProducerConfiguration {
     private long requestTimeout = 6000L;
     private String tempDirectory = "";
     private boolean verifyCertificate = true;
-    private ThreadingModel threadingModel = ThreadingModel.POOLED;
+    private ThreadingModel threadingModel = ThreadingModel.PER_REQUEST;
     private int threadPoolSize = 0;
 
     /**

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -1111,22 +1111,22 @@ public final class Config {
     boolean getVerifyCertificate();
 
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
      */
     boolean hasThreadConfig();
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
      */
     com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig();
 
     /**
-     * <code>optional uint32 max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
      */
-    boolean hasMaxThreads();
+    boolean hasThreadPoolSize();
     /**
-     * <code>optional uint32 max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
      */
-    int getMaxThreads();
+    int getThreadPoolSize();
   }
   /**
    * Protobuf type {@code aws.kinesis.protobuf.Configuration}
@@ -1325,7 +1325,7 @@ public final class Config {
             }
             case 216: {
               bitField0_ |= 0x04000000;
-              maxThreads_ = input.readUInt32();
+              threadPoolSize_ = input.readUInt32();
               break;
             }
             case 1026: {
@@ -1384,9 +1384,9 @@ public final class Config {
     public enum ThreadConfig
         implements com.google.protobuf.ProtocolMessageEnum {
       /**
-       * <code>DEFAULT = 0;</code>
+       * <code>PER_REQUEST = 0;</code>
        */
-      DEFAULT(0, 0),
+      PER_REQUEST(0, 0),
       /**
        * <code>POOLED = 1;</code>
        */
@@ -1394,9 +1394,9 @@ public final class Config {
       ;
 
       /**
-       * <code>DEFAULT = 0;</code>
+       * <code>PER_REQUEST = 0;</code>
        */
-      public static final int DEFAULT_VALUE = 0;
+      public static final int PER_REQUEST_VALUE = 0;
       /**
        * <code>POOLED = 1;</code>
        */
@@ -1407,7 +1407,7 @@ public final class Config {
 
       public static ThreadConfig valueOf(int value) {
         switch (value) {
-          case 0: return DEFAULT;
+          case 0: return PER_REQUEST;
           case 1: return POOLED;
           default: return null;
         }
@@ -2063,31 +2063,31 @@ public final class Config {
     public static final int THREAD_CONFIG_FIELD_NUMBER = 26;
     private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_;
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
      */
     public boolean hasThreadConfig() {
       return ((bitField0_ & 0x02000000) == 0x02000000);
     }
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
      */
     public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
       return threadConfig_;
     }
 
-    public static final int MAX_THREADS_FIELD_NUMBER = 27;
-    private int maxThreads_;
+    public static final int THREAD_POOL_SIZE_FIELD_NUMBER = 27;
+    private int threadPoolSize_;
     /**
-     * <code>optional uint32 max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
      */
-    public boolean hasMaxThreads() {
+    public boolean hasThreadPoolSize() {
       return ((bitField0_ & 0x04000000) == 0x04000000);
     }
     /**
-     * <code>optional uint32 max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
      */
-    public int getMaxThreads() {
-      return maxThreads_;
+    public int getThreadPoolSize() {
+      return threadPoolSize_;
     }
 
     private void initFields() {
@@ -2117,8 +2117,8 @@ public final class Config {
       region_ = "";
       requestTimeout_ = 6000L;
       verifyCertificate_ = true;
-      threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
-      maxThreads_ = 32;
+      threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
+      threadPoolSize_ = 64;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2218,7 +2218,7 @@ public final class Config {
         output.writeEnum(26, threadConfig_.getNumber());
       }
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
-        output.writeUInt32(27, maxThreads_);
+        output.writeUInt32(27, threadPoolSize_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         output.writeMessage(128, additionalMetricDims_.get(i));
@@ -2338,7 +2338,7 @@ public final class Config {
       }
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(27, maxThreads_);
+          .computeUInt32Size(27, threadPoolSize_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
@@ -2518,9 +2518,9 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x01000000);
         verifyCertificate_ = true;
         bitField0_ = (bitField0_ & ~0x02000000);
-        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
         bitField0_ = (bitField0_ & ~0x04000000);
-        maxThreads_ = 32;
+        threadPoolSize_ = 64;
         bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
@@ -2666,7 +2666,7 @@ public final class Config {
         if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
           to_bitField0_ |= 0x04000000;
         }
-        result.maxThreads_ = maxThreads_;
+        result.threadPoolSize_ = threadPoolSize_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2801,8 +2801,8 @@ public final class Config {
         if (other.hasThreadConfig()) {
           setThreadConfig(other.getThreadConfig());
         }
-        if (other.hasMaxThreads()) {
-          setMaxThreads(other.getMaxThreads());
+        if (other.hasThreadPoolSize()) {
+          setThreadPoolSize(other.getThreadPoolSize());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4185,21 +4185,21 @@ public final class Config {
         return this;
       }
 
-      private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+      private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
        */
       public boolean hasThreadConfig() {
         return ((bitField0_ & 0x04000000) == 0x04000000);
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
         return threadConfig_;
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
        */
       public Builder setThreadConfig(com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig value) {
         if (value == null) {
@@ -4211,43 +4211,43 @@ public final class Config {
         return this;
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
        */
       public Builder clearThreadConfig() {
         bitField0_ = (bitField0_ & ~0x04000000);
-        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
         onChanged();
         return this;
       }
 
-      private int maxThreads_ = 32;
+      private int threadPoolSize_ = 64;
       /**
-       * <code>optional uint32 max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
        */
-      public boolean hasMaxThreads() {
+      public boolean hasThreadPoolSize() {
         return ((bitField0_ & 0x08000000) == 0x08000000);
       }
       /**
-       * <code>optional uint32 max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
        */
-      public int getMaxThreads() {
-        return maxThreads_;
+      public int getThreadPoolSize() {
+        return threadPoolSize_;
       }
       /**
-       * <code>optional uint32 max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
        */
-      public Builder setMaxThreads(int value) {
+      public Builder setThreadPoolSize(int value) {
         bitField0_ |= 0x08000000;
-        maxThreads_ = value;
+        threadPoolSize_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional uint32 max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 thread_pool_size = 27 [default = 64];</code>
        */
-      public Builder clearMaxThreads() {
+      public Builder clearThreadPoolSize() {
         bitField0_ = (bitField0_ & ~0x08000000);
-        maxThreads_ = 32;
+        threadPoolSize_ = 64;
         onChanged();
         return this;
       }
@@ -4284,7 +4284,7 @@ public final class Config {
     java.lang.String[] descriptorData = {
       "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
       "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\237\010\n\rConfigu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\247\010\n\rConfigu" +
       "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
       ").aws.kinesis.protobuf.AdditionalDimensi" +
       "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
@@ -4307,12 +4307,12 @@ public final class Config {
       "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t" +
       "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req" +
       "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
-      "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001(" +
+      "ficate\030\031 \001(\010:\004true\022O\n\rthread_config\030\032 \001(" +
       "\01620.aws.kinesis.protobuf.Configuration.T" +
-      "hreadConfig:\007DEFAULT\022\027\n\013max_threads\030\033 \001(" +
-      "\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEFAULT\020\000\022\n\n\006PO" +
-      "OLED\020\001B2\n0com.amazonaws.services.kinesis",
-      ".producer.protobuf"
+      "hreadConfig:\006POOLED\022\034\n\020thread_pool_size\030" +
+      "\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST" +
+      "\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.services",
+      ".kinesis.producer.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4337,7 +4337,7 @@ public final class Config {
     internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_aws_kinesis_protobuf_Configuration_descriptor,
-        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", "MaxThreads", });
+        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", "ThreadPoolSize", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -1118,6 +1118,15 @@ public final class Config {
      * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
      */
     com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig();
+
+    /**
+     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     */
+    boolean hasThreadPoolMaxThreads();
+    /**
+     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     */
+    int getThreadPoolMaxThreads();
   }
   /**
    * Protobuf type {@code aws.kinesis.protobuf.Configuration}
@@ -1312,6 +1321,11 @@ public final class Config {
                 bitField0_ |= 0x02000000;
                 threadConfig_ = value;
               }
+              break;
+            }
+            case 216: {
+              bitField0_ |= 0x04000000;
+              threadPoolMaxThreads_ = input.readUInt32();
               break;
             }
             case 1026: {
@@ -2061,6 +2075,21 @@ public final class Config {
       return threadConfig_;
     }
 
+    public static final int THREAD_POOL_MAX_THREADS_FIELD_NUMBER = 27;
+    private int threadPoolMaxThreads_;
+    /**
+     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     */
+    public boolean hasThreadPoolMaxThreads() {
+      return ((bitField0_ & 0x04000000) == 0x04000000);
+    }
+    /**
+     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     */
+    public int getThreadPoolMaxThreads() {
+      return threadPoolMaxThreads_;
+    }
+
     private void initFields() {
       additionalMetricDims_ = java.util.Collections.emptyList();
       aggregationEnabled_ = true;
@@ -2089,6 +2118,7 @@ public final class Config {
       requestTimeout_ = 6000L;
       verifyCertificate_ = true;
       threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+      threadPoolMaxThreads_ = 32;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2186,6 +2216,9 @@ public final class Config {
       }
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         output.writeEnum(26, threadConfig_.getNumber());
+      }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        output.writeUInt32(27, threadPoolMaxThreads_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         output.writeMessage(128, additionalMetricDims_.get(i));
@@ -2302,6 +2335,10 @@ public final class Config {
       if (((bitField0_ & 0x02000000) == 0x02000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(26, threadConfig_.getNumber());
+      }
+      if (((bitField0_ & 0x04000000) == 0x04000000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(27, threadPoolMaxThreads_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
@@ -2483,6 +2520,8 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x02000000);
         threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
         bitField0_ = (bitField0_ & ~0x04000000);
+        threadPoolMaxThreads_ = 32;
+        bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
 
@@ -2624,6 +2663,10 @@ public final class Config {
           to_bitField0_ |= 0x02000000;
         }
         result.threadConfig_ = threadConfig_;
+        if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
+          to_bitField0_ |= 0x04000000;
+        }
+        result.threadPoolMaxThreads_ = threadPoolMaxThreads_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2757,6 +2800,9 @@ public final class Config {
         }
         if (other.hasThreadConfig()) {
           setThreadConfig(other.getThreadConfig());
+        }
+        if (other.hasThreadPoolMaxThreads()) {
+          setThreadPoolMaxThreads(other.getThreadPoolMaxThreads());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4174,6 +4220,38 @@ public final class Config {
         return this;
       }
 
+      private int threadPoolMaxThreads_ = 32;
+      /**
+       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       */
+      public boolean hasThreadPoolMaxThreads() {
+        return ((bitField0_ & 0x08000000) == 0x08000000);
+      }
+      /**
+       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       */
+      public int getThreadPoolMaxThreads() {
+        return threadPoolMaxThreads_;
+      }
+      /**
+       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       */
+      public Builder setThreadPoolMaxThreads(int value) {
+        bitField0_ |= 0x08000000;
+        threadPoolMaxThreads_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       */
+      public Builder clearThreadPoolMaxThreads() {
+        bitField0_ = (bitField0_ & ~0x08000000);
+        threadPoolMaxThreads_ = 32;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:aws.kinesis.protobuf.Configuration)
     }
 
@@ -4206,7 +4284,7 @@ public final class Config {
     java.lang.String[] descriptorData = {
       "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
       "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\206\010\n\rConfigu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\253\010\n\rConfigu" +
       "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
       ").aws.kinesis.protobuf.AdditionalDimensi" +
       "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
@@ -4231,9 +4309,10 @@ public final class Config {
       "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
       "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001(" +
       "\01620.aws.kinesis.protobuf.Configuration.T" +
-      "hreadConfig:\007DEFAULT\"\'\n\014ThreadConfig\022\013\n\007" +
-      "DEFAULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.s" +
-      "ervices.kinesis.producer.protobuf"
+      "hreadConfig:\007DEFAULT\022#\n\027thread_pool_max_" +
+      "threads\030\033 \001(\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEF" +
+      "AULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.serv",
+      "ices.kinesis.producer.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4258,7 +4337,7 @@ public final class Config {
     internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_aws_kinesis_protobuf_Configuration_descriptor,
-        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", });
+        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", "ThreadPoolMaxThreads", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -1111,11 +1111,11 @@ public final class Config {
     boolean getVerifyCertificate();
 
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
      */
     boolean hasThreadConfig();
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
      */
     com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig();
 
@@ -2063,13 +2063,13 @@ public final class Config {
     public static final int THREAD_CONFIG_FIELD_NUMBER = 26;
     private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_;
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
      */
     public boolean hasThreadConfig() {
       return ((bitField0_ & 0x02000000) == 0x02000000);
     }
     /**
-     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
      */
     public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
       return threadConfig_;
@@ -2117,7 +2117,7 @@ public final class Config {
       region_ = "";
       requestTimeout_ = 6000L;
       verifyCertificate_ = true;
-      threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
+      threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.PER_REQUEST;
       threadPoolSize_ = 64;
     }
     private byte memoizedIsInitialized = -1;
@@ -2518,7 +2518,7 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x01000000);
         verifyCertificate_ = true;
         bitField0_ = (bitField0_ & ~0x02000000);
-        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.PER_REQUEST;
         bitField0_ = (bitField0_ & ~0x04000000);
         threadPoolSize_ = 64;
         bitField0_ = (bitField0_ & ~0x08000000);
@@ -4185,21 +4185,21 @@ public final class Config {
         return this;
       }
 
-      private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
+      private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.PER_REQUEST;
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
        */
       public boolean hasThreadConfig() {
         return ((bitField0_ & 0x04000000) == 0x04000000);
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
         return threadConfig_;
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
        */
       public Builder setThreadConfig(com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig value) {
         if (value == null) {
@@ -4211,11 +4211,11 @@ public final class Config {
         return this;
       }
       /**
-       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = POOLED];</code>
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = PER_REQUEST];</code>
        */
       public Builder clearThreadConfig() {
         bitField0_ = (bitField0_ & ~0x04000000);
-        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.POOLED;
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.PER_REQUEST;
         onChanged();
         return this;
       }
@@ -4284,7 +4284,7 @@ public final class Config {
     java.lang.String[] descriptorData = {
       "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
       "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\247\010\n\rConfigu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\254\010\n\rConfigu" +
       "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
       ").aws.kinesis.protobuf.AdditionalDimensi" +
       "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
@@ -4307,12 +4307,12 @@ public final class Config {
       "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t" +
       "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req" +
       "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
-      "ficate\030\031 \001(\010:\004true\022O\n\rthread_config\030\032 \001(" +
+      "ficate\030\031 \001(\010:\004true\022T\n\rthread_config\030\032 \001(" +
       "\01620.aws.kinesis.protobuf.Configuration.T" +
-      "hreadConfig:\006POOLED\022\034\n\020thread_pool_size\030" +
-      "\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST" +
-      "\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.services",
-      ".kinesis.producer.protobuf"
+      "hreadConfig:\013PER_REQUEST\022\034\n\020thread_pool_" +
+      "size\030\033 \001(\r:\00264\"+\n\014ThreadConfig\022\017\n\013PER_RE" +
+      "QUEST\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.ser",
+      "vices.kinesis.producer.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -1120,13 +1120,13 @@ public final class Config {
     com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig();
 
     /**
-     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 max_threads = 27 [default = 32];</code>
      */
-    boolean hasThreadPoolMaxThreads();
+    boolean hasMaxThreads();
     /**
-     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 max_threads = 27 [default = 32];</code>
      */
-    int getThreadPoolMaxThreads();
+    int getMaxThreads();
   }
   /**
    * Protobuf type {@code aws.kinesis.protobuf.Configuration}
@@ -1325,7 +1325,7 @@ public final class Config {
             }
             case 216: {
               bitField0_ |= 0x04000000;
-              threadPoolMaxThreads_ = input.readUInt32();
+              maxThreads_ = input.readUInt32();
               break;
             }
             case 1026: {
@@ -2075,19 +2075,19 @@ public final class Config {
       return threadConfig_;
     }
 
-    public static final int THREAD_POOL_MAX_THREADS_FIELD_NUMBER = 27;
-    private int threadPoolMaxThreads_;
+    public static final int MAX_THREADS_FIELD_NUMBER = 27;
+    private int maxThreads_;
     /**
-     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 max_threads = 27 [default = 32];</code>
      */
-    public boolean hasThreadPoolMaxThreads() {
+    public boolean hasMaxThreads() {
       return ((bitField0_ & 0x04000000) == 0x04000000);
     }
     /**
-     * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+     * <code>optional uint32 max_threads = 27 [default = 32];</code>
      */
-    public int getThreadPoolMaxThreads() {
-      return threadPoolMaxThreads_;
+    public int getMaxThreads() {
+      return maxThreads_;
     }
 
     private void initFields() {
@@ -2118,7 +2118,7 @@ public final class Config {
       requestTimeout_ = 6000L;
       verifyCertificate_ = true;
       threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
-      threadPoolMaxThreads_ = 32;
+      maxThreads_ = 32;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2218,7 +2218,7 @@ public final class Config {
         output.writeEnum(26, threadConfig_.getNumber());
       }
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
-        output.writeUInt32(27, threadPoolMaxThreads_);
+        output.writeUInt32(27, maxThreads_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         output.writeMessage(128, additionalMetricDims_.get(i));
@@ -2338,7 +2338,7 @@ public final class Config {
       }
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt32Size(27, threadPoolMaxThreads_);
+          .computeUInt32Size(27, maxThreads_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
@@ -2520,7 +2520,7 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x02000000);
         threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
         bitField0_ = (bitField0_ & ~0x04000000);
-        threadPoolMaxThreads_ = 32;
+        maxThreads_ = 32;
         bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
@@ -2666,7 +2666,7 @@ public final class Config {
         if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
           to_bitField0_ |= 0x04000000;
         }
-        result.threadPoolMaxThreads_ = threadPoolMaxThreads_;
+        result.maxThreads_ = maxThreads_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2801,8 +2801,8 @@ public final class Config {
         if (other.hasThreadConfig()) {
           setThreadConfig(other.getThreadConfig());
         }
-        if (other.hasThreadPoolMaxThreads()) {
-          setThreadPoolMaxThreads(other.getThreadPoolMaxThreads());
+        if (other.hasMaxThreads()) {
+          setMaxThreads(other.getMaxThreads());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -4220,34 +4220,34 @@ public final class Config {
         return this;
       }
 
-      private int threadPoolMaxThreads_ = 32;
+      private int maxThreads_ = 32;
       /**
-       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 max_threads = 27 [default = 32];</code>
        */
-      public boolean hasThreadPoolMaxThreads() {
+      public boolean hasMaxThreads() {
         return ((bitField0_ & 0x08000000) == 0x08000000);
       }
       /**
-       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 max_threads = 27 [default = 32];</code>
        */
-      public int getThreadPoolMaxThreads() {
-        return threadPoolMaxThreads_;
+      public int getMaxThreads() {
+        return maxThreads_;
       }
       /**
-       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 max_threads = 27 [default = 32];</code>
        */
-      public Builder setThreadPoolMaxThreads(int value) {
+      public Builder setMaxThreads(int value) {
         bitField0_ |= 0x08000000;
-        threadPoolMaxThreads_ = value;
+        maxThreads_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>optional uint32 thread_pool_max_threads = 27 [default = 32];</code>
+       * <code>optional uint32 max_threads = 27 [default = 32];</code>
        */
-      public Builder clearThreadPoolMaxThreads() {
+      public Builder clearMaxThreads() {
         bitField0_ = (bitField0_ & ~0x08000000);
-        threadPoolMaxThreads_ = 32;
+        maxThreads_ = 32;
         onChanged();
         return this;
       }
@@ -4284,7 +4284,7 @@ public final class Config {
     java.lang.String[] descriptorData = {
       "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
       "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\253\010\n\rConfigu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\237\010\n\rConfigu" +
       "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
       ").aws.kinesis.protobuf.AdditionalDimensi" +
       "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
@@ -4309,10 +4309,10 @@ public final class Config {
       "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
       "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001(" +
       "\01620.aws.kinesis.protobuf.Configuration.T" +
-      "hreadConfig:\007DEFAULT\022#\n\027thread_pool_max_" +
-      "threads\030\033 \001(\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEF" +
-      "AULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.serv",
-      "ices.kinesis.producer.protobuf"
+      "hreadConfig:\007DEFAULT\022\027\n\013max_threads\030\033 \001(" +
+      "\r:\00232\"\'\n\014ThreadConfig\022\013\n\007DEFAULT\020\000\022\n\n\006PO" +
+      "OLED\020\001B2\n0com.amazonaws.services.kinesis",
+      ".producer.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4337,7 +4337,7 @@ public final class Config {
     internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_aws_kinesis_protobuf_Configuration_descriptor,
-        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", "ThreadPoolMaxThreads", });
+        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", "MaxThreads", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -9,7 +9,7 @@ public final class Config {
       com.google.protobuf.ExtensionRegistry registry) {
   }
   public interface AdditionalDimensionOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension)
+      // @@protoc_insertion_point(interface_extends:aws.kinesis.protobuf.AdditionalDimension)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -55,11 +55,11 @@ public final class Config {
         getGranularityBytes();
   }
   /**
-   * Protobuf type {@code com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension}
+   * Protobuf type {@code aws.kinesis.protobuf.AdditionalDimension}
    */
   public static final class AdditionalDimension extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension)
+      // @@protoc_insertion_point(message_implements:aws.kinesis.protobuf.AdditionalDimension)
       AdditionalDimensionOrBuilder {
     // Use AdditionalDimension.newBuilder() to construct.
     private AdditionalDimension(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -138,12 +138,12 @@ public final class Config {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor;
+      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_fieldAccessorTable
+      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_AdditionalDimension_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.class, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder.class);
     }
@@ -429,20 +429,20 @@ public final class Config {
       return builder;
     }
     /**
-     * Protobuf type {@code com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension}
+     * Protobuf type {@code aws.kinesis.protobuf.AdditionalDimension}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension)
+        // @@protoc_insertion_point(builder_implements:aws.kinesis.protobuf.AdditionalDimension)
         com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor;
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_fieldAccessorTable
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_AdditionalDimension_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.class, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder.class);
       }
@@ -482,7 +482,7 @@ public final class Config {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor;
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor;
       }
 
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension getDefaultInstanceForType() {
@@ -811,7 +811,7 @@ public final class Config {
         return this;
       }
 
-      // @@protoc_insertion_point(builder_scope:com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension)
+      // @@protoc_insertion_point(builder_scope:aws.kinesis.protobuf.AdditionalDimension)
     }
 
     static {
@@ -819,33 +819,33 @@ public final class Config {
       defaultInstance.initFields();
     }
 
-    // @@protoc_insertion_point(class_scope:com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension)
+    // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.AdditionalDimension)
   }
 
   public interface ConfigurationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:com.amazonaws.services.kinesis.producer.protobuf.Configuration)
+      // @@protoc_insertion_point(interface_extends:aws.kinesis.protobuf.Configuration)
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> 
         getAdditionalMetricDimsList();
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension getAdditionalMetricDims(int index);
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     int getAdditionalMetricDimsCount();
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
         getAdditionalMetricDimsOrBuilderList();
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder getAdditionalMetricDimsOrBuilder(
         int index);
@@ -1109,13 +1109,22 @@ public final class Config {
      * <code>optional bool verify_certificate = 25 [default = true];</code>
      */
     boolean getVerifyCertificate();
+
+    /**
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     */
+    boolean hasThreadConfig();
+    /**
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     */
+    com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig();
   }
   /**
-   * Protobuf type {@code com.amazonaws.services.kinesis.producer.protobuf.Configuration}
+   * Protobuf type {@code aws.kinesis.protobuf.Configuration}
    */
   public static final class Configuration extends
       com.google.protobuf.GeneratedMessage implements
-      // @@protoc_insertion_point(message_implements:com.amazonaws.services.kinesis.producer.protobuf.Configuration)
+      // @@protoc_insertion_point(message_implements:aws.kinesis.protobuf.Configuration)
       ConfigurationOrBuilder {
     // Use Configuration.newBuilder() to construct.
     private Configuration(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
@@ -1294,6 +1303,17 @@ public final class Config {
               verifyCertificate_ = input.readBool();
               break;
             }
+            case 208: {
+              int rawValue = input.readEnum();
+              com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig value = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(26, rawValue);
+              } else {
+                bitField0_ |= 0x02000000;
+                threadConfig_ = value;
+              }
+              break;
+            }
             case 1026: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 additionalMetricDims_ = new java.util.ArrayList<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension>();
@@ -1319,12 +1339,12 @@ public final class Config {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor;
+      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_Configuration_descriptor;
     }
 
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_fieldAccessorTable
+      return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.class, com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.Builder.class);
     }
@@ -1344,36 +1364,118 @@ public final class Config {
       return PARSER;
     }
 
+    /**
+     * Protobuf enum {@code aws.kinesis.protobuf.Configuration.ThreadConfig}
+     */
+    public enum ThreadConfig
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>DEFAULT = 0;</code>
+       */
+      DEFAULT(0, 0),
+      /**
+       * <code>POOLED = 1;</code>
+       */
+      POOLED(1, 1),
+      ;
+
+      /**
+       * <code>DEFAULT = 0;</code>
+       */
+      public static final int DEFAULT_VALUE = 0;
+      /**
+       * <code>POOLED = 1;</code>
+       */
+      public static final int POOLED_VALUE = 1;
+
+
+      public final int getNumber() { return value; }
+
+      public static ThreadConfig valueOf(int value) {
+        switch (value) {
+          case 0: return DEFAULT;
+          case 1: return POOLED;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<ThreadConfig>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<ThreadConfig>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<ThreadConfig>() {
+              public ThreadConfig findValueByNumber(int number) {
+                return ThreadConfig.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final ThreadConfig[] VALUES = values();
+
+      public static ThreadConfig valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private ThreadConfig(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:aws.kinesis.protobuf.Configuration.ThreadConfig)
+    }
+
     private int bitField0_;
     public static final int ADDITIONAL_METRIC_DIMS_FIELD_NUMBER = 128;
     private java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> additionalMetricDims_;
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     public java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> getAdditionalMetricDimsList() {
       return additionalMetricDims_;
     }
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
         getAdditionalMetricDimsOrBuilderList() {
       return additionalMetricDims_;
     }
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     public int getAdditionalMetricDimsCount() {
       return additionalMetricDims_.size();
     }
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension getAdditionalMetricDims(int index) {
       return additionalMetricDims_.get(index);
     }
     /**
-     * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+     * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
     public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder getAdditionalMetricDimsOrBuilder(
         int index) {
@@ -1944,6 +2046,21 @@ public final class Config {
       return verifyCertificate_;
     }
 
+    public static final int THREAD_CONFIG_FIELD_NUMBER = 26;
+    private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_;
+    /**
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     */
+    public boolean hasThreadConfig() {
+      return ((bitField0_ & 0x02000000) == 0x02000000);
+    }
+    /**
+     * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+     */
+    public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
+      return threadConfig_;
+    }
+
     private void initFields() {
       additionalMetricDims_ = java.util.Collections.emptyList();
       aggregationEnabled_ = true;
@@ -1971,6 +2088,7 @@ public final class Config {
       region_ = "";
       requestTimeout_ = 6000L;
       verifyCertificate_ = true;
+      threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -2065,6 +2183,9 @@ public final class Config {
       }
       if (((bitField0_ & 0x01000000) == 0x01000000)) {
         output.writeBool(25, verifyCertificate_);
+      }
+      if (((bitField0_ & 0x02000000) == 0x02000000)) {
+        output.writeEnum(26, threadConfig_.getNumber());
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         output.writeMessage(128, additionalMetricDims_.get(i));
@@ -2178,6 +2299,10 @@ public final class Config {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(25, verifyCertificate_);
       }
+      if (((bitField0_ & 0x02000000) == 0x02000000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(26, threadConfig_.getNumber());
+      }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(128, additionalMetricDims_.get(i));
@@ -2261,20 +2386,20 @@ public final class Config {
       return builder;
     }
     /**
-     * Protobuf type {@code com.amazonaws.services.kinesis.producer.protobuf.Configuration}
+     * Protobuf type {@code aws.kinesis.protobuf.Configuration}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessage.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:com.amazonaws.services.kinesis.producer.protobuf.Configuration)
+        // @@protoc_insertion_point(builder_implements:aws.kinesis.protobuf.Configuration)
         com.amazonaws.services.kinesis.producer.protobuf.Config.ConfigurationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor;
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_Configuration_descriptor;
       }
 
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_fieldAccessorTable
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
                 com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.class, com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.Builder.class);
       }
@@ -2356,6 +2481,8 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x01000000);
         verifyCertificate_ = true;
         bitField0_ = (bitField0_ & ~0x02000000);
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+        bitField0_ = (bitField0_ & ~0x04000000);
         return this;
       }
 
@@ -2365,7 +2492,7 @@ public final class Config {
 
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor;
+        return com.amazonaws.services.kinesis.producer.protobuf.Config.internal_static_aws_kinesis_protobuf_Configuration_descriptor;
       }
 
       public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration getDefaultInstanceForType() {
@@ -2493,6 +2620,10 @@ public final class Config {
           to_bitField0_ |= 0x01000000;
         }
         result.verifyCertificate_ = verifyCertificate_;
+        if (((from_bitField0_ & 0x04000000) == 0x04000000)) {
+          to_bitField0_ |= 0x02000000;
+        }
+        result.threadConfig_ = threadConfig_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2624,6 +2755,9 @@ public final class Config {
         if (other.hasVerifyCertificate()) {
           setVerifyCertificate(other.getVerifyCertificate());
         }
+        if (other.hasThreadConfig()) {
+          setThreadConfig(other.getThreadConfig());
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -2670,7 +2804,7 @@ public final class Config {
           com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> additionalMetricDimsBuilder_;
 
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> getAdditionalMetricDimsList() {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2680,7 +2814,7 @@ public final class Config {
         }
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public int getAdditionalMetricDimsCount() {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2690,7 +2824,7 @@ public final class Config {
         }
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension getAdditionalMetricDims(int index) {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2700,7 +2834,7 @@ public final class Config {
         }
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder setAdditionalMetricDims(
           int index, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension value) {
@@ -2717,7 +2851,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder setAdditionalMetricDims(
           int index, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder builderForValue) {
@@ -2731,7 +2865,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder addAdditionalMetricDims(com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension value) {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2747,7 +2881,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder addAdditionalMetricDims(
           int index, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension value) {
@@ -2764,7 +2898,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder addAdditionalMetricDims(
           com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder builderForValue) {
@@ -2778,7 +2912,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder addAdditionalMetricDims(
           int index, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder builderForValue) {
@@ -2792,7 +2926,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder addAllAdditionalMetricDims(
           java.lang.Iterable<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> values) {
@@ -2807,7 +2941,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder clearAdditionalMetricDims() {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2820,7 +2954,7 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public Builder removeAdditionalMetricDims(int index) {
         if (additionalMetricDimsBuilder_ == null) {
@@ -2833,14 +2967,14 @@ public final class Config {
         return this;
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder getAdditionalMetricDimsBuilder(
           int index) {
         return getAdditionalMetricDimsFieldBuilder().getBuilder(index);
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder getAdditionalMetricDimsOrBuilder(
           int index) {
@@ -2850,7 +2984,7 @@ public final class Config {
         }
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
            getAdditionalMetricDimsOrBuilderList() {
@@ -2861,14 +2995,14 @@ public final class Config {
         }
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder addAdditionalMetricDimsBuilder() {
         return getAdditionalMetricDimsFieldBuilder().addBuilder(
             com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.getDefaultInstance());
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder addAdditionalMetricDimsBuilder(
           int index) {
@@ -2876,7 +3010,7 @@ public final class Config {
             index, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.getDefaultInstance());
       }
       /**
-       * <code>repeated .com.amazonaws.services.kinesis.producer.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
+       * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
       public java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder> 
            getAdditionalMetricDimsBuilderList() {
@@ -4005,7 +4139,42 @@ public final class Config {
         return this;
       }
 
-      // @@protoc_insertion_point(builder_scope:com.amazonaws.services.kinesis.producer.protobuf.Configuration)
+      private com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+      /**
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       */
+      public boolean hasThreadConfig() {
+        return ((bitField0_ & 0x04000000) == 0x04000000);
+      }
+      /**
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       */
+      public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig getThreadConfig() {
+        return threadConfig_;
+      }
+      /**
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       */
+      public Builder setThreadConfig(com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x04000000;
+        threadConfig_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 26 [default = DEFAULT];</code>
+       */
+      public Builder clearThreadConfig() {
+        bitField0_ = (bitField0_ & ~0x04000000);
+        threadConfig_ = com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration.ThreadConfig.DEFAULT;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:aws.kinesis.protobuf.Configuration)
     }
 
     static {
@@ -4013,19 +4182,19 @@ public final class Config {
       defaultInstance.initFields();
     }
 
-    // @@protoc_insertion_point(class_scope:com.amazonaws.services.kinesis.producer.protobuf.Configuration)
+    // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
   }
 
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor;
+    internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_fieldAccessorTable;
+      internal_static_aws_kinesis_protobuf_AdditionalDimension_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor;
+    internal_static_aws_kinesis_protobuf_Configuration_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
-      internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_fieldAccessorTable;
+      internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -4035,33 +4204,36 @@ public final class Config {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\014config.proto\0220com.amazonaws.services.k" +
-      "inesis.producer.protobuf\"F\n\023AdditionalDi" +
-      "mension\022\013\n\003key\030\001 \002(\t\022\r\n\005value\030\002 \002(\t\022\023\n\013g" +
-      "ranularity\030\003 \002(\t\"\247\007\n\rConfiguration\022f\n\026ad" +
-      "ditional_metric_dims\030\200\001 \003(\0132E.com.amazon" +
-      "aws.services.kinesis.producer.protobuf.A" +
-      "dditionalDimension\022!\n\023aggregation_enable" +
-      "d\030\001 \001(\010:\004true\022)\n\025aggregation_max_count\030\002" +
-      " \001(\004:\n4294967295\022#\n\024aggregation_max_size" +
-      "\030\003 \001(\004:\00551200\022\035\n\023cloudwatch_endpoint\030\004 \001",
-      "(\t:\000\022\034\n\017cloudwatch_port\030\005 \001(\004:\003443\022!\n\024co" +
-      "llection_max_count\030\006 \001(\004:\003500\022$\n\023collect" +
-      "ion_max_size\030\007 \001(\004:\0075242880\022\035\n\017connect_t" +
-      "imeout\030\010 \001(\004:\0046000\022 \n\021enable_core_dumps\030" +
-      "\t \001(\010:\005false\022 \n\021fail_if_throttled\030\n \001(\010:" +
-      "\005false\022\032\n\020kinesis_endpoint\030\013 \001(\t:\000\022\031\n\014ki" +
-      "nesis_port\030\014 \001(\004:\003443\022\027\n\tlog_level\030\r \001(\t" +
-      ":\004info\022\033\n\017max_connections\030\016 \001(\004:\00224\022\"\n\023m" +
-      "etrics_granularity\030\017 \001(\t:\005shard\022\037\n\rmetri" +
-      "cs_level\030\020 \001(\t:\010detailed\0221\n\021metrics_name",
-      "space\030\021 \001(\t:\026KinesisProducerLibrary\022#\n\024m" +
-      "etrics_upload_delay\030\022 \001(\004:\00560000\022\032\n\017min_" +
-      "connections\030\023 \001(\004:\0011\022\027\n\nrate_limit\030\024 \001(\004" +
-      ":\003150\022%\n\030record_max_buffered_time\030\025 \001(\004:" +
-      "\003100\022\031\n\nrecord_ttl\030\026 \001(\004:\00530000\022\020\n\006regio" +
-      "n\030\027 \001(\t:\000\022\035\n\017request_timeout\030\030 \001(\004:\0046000" +
-      "\022 \n\022verify_certificate\030\031 \001(\010:\004true"
+      "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
+      "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\206\010\n\rConfigu" +
+      "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
+      ").aws.kinesis.protobuf.AdditionalDimensi" +
+      "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
+      "\025aggregation_max_count\030\002 \001(\004:\n4294967295" +
+      "\022#\n\024aggregation_max_size\030\003 \001(\004:\00551200\022\035\n" +
+      "\023cloudwatch_endpoint\030\004 \001(\t:\000\022\034\n\017cloudwat" +
+      "ch_port\030\005 \001(\004:\003443\022!\n\024collection_max_cou",
+      "nt\030\006 \001(\004:\003500\022$\n\023collection_max_size\030\007 \001" +
+      "(\004:\0075242880\022\035\n\017connect_timeout\030\010 \001(\004:\00460" +
+      "00\022 \n\021enable_core_dumps\030\t \001(\010:\005false\022 \n\021" +
+      "fail_if_throttled\030\n \001(\010:\005false\022\032\n\020kinesi" +
+      "s_endpoint\030\013 \001(\t:\000\022\031\n\014kinesis_port\030\014 \001(\004" +
+      ":\003443\022\027\n\tlog_level\030\r \001(\t:\004info\022\033\n\017max_co" +
+      "nnections\030\016 \001(\004:\00224\022\"\n\023metrics_granulari" +
+      "ty\030\017 \001(\t:\005shard\022\037\n\rmetrics_level\030\020 \001(\t:\010" +
+      "detailed\0221\n\021metrics_namespace\030\021 \001(\t:\026Kin" +
+      "esisProducerLibrary\022#\n\024metrics_upload_de",
+      "lay\030\022 \001(\004:\00560000\022\032\n\017min_connections\030\023 \001(" +
+      "\004:\0011\022\027\n\nrate_limit\030\024 \001(\004:\003150\022%\n\030record_" +
+      "max_buffered_time\030\025 \001(\004:\003100\022\031\n\nrecord_t" +
+      "tl\030\026 \001(\004:\00530000\022\020\n\006region\030\027 \001(\t:\000\022\035\n\017req" +
+      "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
+      "ficate\030\031 \001(\010:\004true\022P\n\rthread_config\030\032 \001(" +
+      "\01620.aws.kinesis.protobuf.Configuration.T" +
+      "hreadConfig:\007DEFAULT\"\'\n\014ThreadConfig\022\013\n\007" +
+      "DEFAULT\020\000\022\n\n\006POOLED\020\001B2\n0com.amazonaws.s" +
+      "ervices.kinesis.producer.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4075,18 +4247,18 @@ public final class Config {
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
         }, assigner);
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor =
+    internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor =
       getDescriptor().getMessageTypes().get(0);
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_fieldAccessorTable = new
+    internal_static_aws_kinesis_protobuf_AdditionalDimension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_com_amazonaws_services_kinesis_producer_protobuf_AdditionalDimension_descriptor,
+        internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor,
         new java.lang.String[] { "Key", "Value", "Granularity", });
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor =
+    internal_static_aws_kinesis_protobuf_Configuration_descriptor =
       getDescriptor().getMessageTypes().get(1);
-    internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_fieldAccessorTable = new
+    internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-        internal_static_com_amazonaws_services_kinesis_producer_protobuf_Configuration_descriptor,
-        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", });
+        internal_static_aws_kinesis_protobuf_Configuration_descriptor,
+        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ThreadConfig", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)


### PR DESCRIPTION
This allows changing the threading model from a per request model to a pooled model.  

# Threading Policies
## Pooled
This uses a queue, and thread pool to execute requests to Kinesis.  This limits the number of threads that the native process may use.  Under extremely heavy load this can increase latency significantly more than the per request model.  

## Per Request
This is the current default for 0.12.x versions of the KPL, and creates a thread for each request to Kinesis.  Under heavy load this can create a very large number of threads, which may cause resource exhaustion.

Updated compiler for Linux from GCC 4.9 to GCC 6.3.