### PR TITLE
Remove the Version Range for Dependencies

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -57,7 +57,7 @@
     </build>
 
     <properties>
-        <aws-sdk-core-version>(1.11.0, 1.12.0]</aws-sdk-core-version>
+        <aws-sdk-core-version>1.11.128</aws-sdk-core-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Removed the version range specifier for aws-java-sdk-core.

See PR #84 