### PR TITLE
Force an older version of glibc by preventing the use of 2.14 memcpy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(amazon_kinesis_producer)
 
-set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_internal_SOURCE_DIR}/third_party/lib")
+set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_SOURCE_DIR}/third_party/lib")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(ADDL_LINK_CONFIG "-static-libstdc++")
+    set(ADDL_LINK_CONFIG "-static-libstdc++ -Wl,--wrap=memcpy")
     add_compile_options("-fpermissive")
+    set(WRAP_MEMCPY aws/utils/wrap_memcpy.c)
 endif ()
 
 IF(CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -71,7 +72,8 @@ set(SOURCE_FILES
         aws/utils/utils.cc
         aws/utils/utils.h
         aws/utils/processing_statistics_logger.cc
-        aws/utils/processing_statistics_logger.h)
+        aws/utils/processing_statistics_logger.h
+        ${WRAP_MEMCPY})
 
 
 

--- a/aws/utils/wrap_memcpy.c
+++ b/aws/utils/wrap_memcpy.c
@@ -1,8 +1,32 @@
+// Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 #include <string.h>
 
-void *__memcpy_glibc_2_2_5(void*, const void*, size_t);
 
-asm(".symver __memcpy_glibc_2_2_5, memcpy@GLIBC_2.2.5");
+/**
+ * Wrapped version of memcpy provided via asm.
+ */
+void *__memcpy_2_2_5(void*, const void*, size_t);
+
+asm(".symver __memcpy_2_2_5, memcpy@GLIBC_2.2.5");
+/**
+ * Wrapped version of memcpy for systems with an older version of glibc.
+ *
+ * memcpy was updated in glibc 2.14, but the the KPL needs to be able to run on some older versions of Linux.
+ * This extracts, and wraps the older version of memcpy, which drops the minimum required version of glibc.
+ *
+ */
 void *__wrap_memcpy(void* dest, const void* src, size_t n) {
   return __memcpy_glibc_2_2_5(dest, src, n);
 }

--- a/aws/utils/wrap_memcpy.c
+++ b/aws/utils/wrap_memcpy.c
@@ -28,5 +28,5 @@ asm(".symver __memcpy_2_2_5, memcpy@GLIBC_2.2.5");
  *
  */
 void *__wrap_memcpy(void* dest, const void* src, size_t n) {
-  return __memcpy_glibc_2_2_5(dest, src, n);
+  return __memcpy_2_2_5(dest, src, n);
 }

--- a/aws/utils/wrap_memcpy.c
+++ b/aws/utils/wrap_memcpy.c
@@ -1,0 +1,8 @@
+#include <string.h>
+
+void *__memcpy_glibc_2_2_5(void*, const void*, size_t);
+
+asm(".symver __memcpy_glibc_2_2_5, memcpy@GLIBC_2.2.5");
+void *__wrap_memcpy(void* dest, const void* src, size_t n) {
+  return __memcpy_glibc_2_2_5(dest, src, n);
+}

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.4</version>
+    <version>0.12.5-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>


### PR DESCRIPTION
During the upgrade to a newer compiler the version of memcpy changed to a newer version of glibc.  This has caused some problems with older versions of Linux.

This change prevents the newer version of memcpy from being linked in to allow using the KPL on older Linux variants.