### PR TITLE
Release 0.12.5 of the Amazon Kinesis Producer Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ For detailed information and installation instructions, see the article [Develop
 
 ## Release Notes
 
+### 0.12.5
+
+#### C++ Core
+
+* Revert to an older version of glibc.
+  * [PR #108](https://github.com/awslabs/amazon-kinesis-producer/pull/108)
+* Update bootstrap.sh to include new compiler options for the newer version of GCC.
+  * [PR #109](https://github.com/awslabs/amazon-kinesis-producer/pull/109)
+
 ### 0.12.4
 
 #### Java

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.12.4</version>
+            <version>0.12.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.5-SNAPSHOT</version>
+    <version>0.12.5</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>


### PR DESCRIPTION
* Revert to an older version of glibc.
  * [PR #108](https://github.com/awslabs/amazon-kinesis-producer/pull/108)
* Update bootstrap.sh to include new compiler options for the newer version of GCC.
  * [PR #109](https://github.com/awslabs/amazon-kinesis-producer/pull/109)