### PR TITLE
Make KPL consumers more testable

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Attempt.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Attempt.java
@@ -33,7 +33,7 @@ public class Attempt {
     private String errorCode;
     private boolean success;
 
-    private Attempt(int delay, int duration, String errorMessage, String errorCode, boolean success) {
+    public Attempt(int delay, int duration, String errorMessage, String errorCode, boolean success) {
         this.delay = delay;
         this.duration = duration;
         this.errorMessage = errorMessage;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/IKinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/IKinesisProducer.java
@@ -1,0 +1,33 @@
+package com.amazonaws.services.kinesis.producer;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import com.google.common.util.concurrent.ListenableFuture;
+
+
+public interface IKinesisProducer {
+    ListenableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, ByteBuffer data);
+
+    ListenableFuture<UserRecordResult> addUserRecord(UserRecord userRecord);
+
+    ListenableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, String explicitHashKey, ByteBuffer data);
+
+    int getOutstandingRecordsCount();
+
+    List<Metric> getMetrics(String metricName, int windowSeconds) throws InterruptedException, ExecutionException;
+
+    List<Metric> getMetrics(String metricName) throws InterruptedException, ExecutionException;
+
+    List<Metric> getMetrics() throws InterruptedException, ExecutionException;
+
+    List<Metric> getMetrics(int windowSeconds) throws InterruptedException, ExecutionException;
+
+    void destroy();
+
+    void flush(String stream);
+
+    void flush();
+
+    void flushSync();
+}

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecord.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecord.java
@@ -1,0 +1,96 @@
+package com.amazonaws.services.kinesis.producer;
+
+import java.nio.ByteBuffer;
+
+public class UserRecord {
+    /**
+     * Stream to put to.
+     */
+    private String streamName;
+
+    /**
+     * Partition key. Length must be at least one, and at most 256 (inclusive).
+     */
+    private String partitionKey;
+
+    /**
+     * The hash value used to explicitly determine the shard the data
+     * record is assigned to by overriding the partition key hash.
+     * Must be a valid string representation of a positive integer
+     * with value between 0 and <tt>2^128 - 1</tt> (inclusive).
+     */
+    private String explicitHashKey;
+
+    /**
+     * Binary data of the record. Maximum size 1MiB.
+     */
+    private ByteBuffer data;
+
+    public UserRecord() {
+    }
+
+    public UserRecord(String streamName, String partitionKey, ByteBuffer data) {
+        this.streamName = streamName;
+        this.partitionKey = partitionKey;
+        this.data = data;
+    }
+
+    public UserRecord(String streamName, String partitionKey, String explicitHashKey, ByteBuffer data) {
+        this.streamName = streamName;
+        this.partitionKey = partitionKey;
+        this.explicitHashKey = explicitHashKey;
+        this.data = data;
+    }
+
+    public String getStreamName() {
+        return streamName;
+    }
+
+    public void setStreamName(String streamName) {
+        this.streamName = streamName;
+    }
+
+    public UserRecord withStreamName(String streamName) {
+        this.streamName = streamName;
+        return this;
+    }
+
+    public String getPartitionKey() {
+        return partitionKey;
+    }
+
+    public void setPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
+
+    public UserRecord withPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+        return this;
+    }
+
+    public ByteBuffer getData() {
+        return data;
+    }
+
+    public void setData(ByteBuffer data) {
+        this.data = data;
+    }
+
+    public UserRecord withData(ByteBuffer byteBuffer) {
+        this.data = byteBuffer;
+        return this;
+    }
+
+    public String getExplicitHashKey() {
+        return explicitHashKey;
+    }
+
+    public void setExplicitHashKey(String explicitHashKey) {
+        this.explicitHashKey = explicitHashKey;
+    }
+
+    public UserRecord withExplicitHashKey(String explicitHashKey) {
+        this.explicitHashKey = explicitHashKey;
+        return this;
+    }
+}

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecordResult.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecordResult.java
@@ -36,7 +36,7 @@ public class UserRecordResult {
     private String shardId;
     private boolean successful;
     
-    private UserRecordResult(List<Attempt> attempts, String sequenceNumber, String shardId, boolean successful) {
+    public UserRecordResult(List<Attempt> attempts, String sequenceNumber, String shardId, boolean successful) {
         this.attempts = attempts;
         this.sequenceNumber = sequenceNumber;
         this.shardId = shardId;


### PR DESCRIPTION
Introduced interface on KinesisProducer for testability/mockability.
Introduced UserRecord object and KinesisProducer.addUserRecord(UserRecord) method.

@pfifer 

This commit was done with 100% backwards compatibility in mind.