### PR TITLE
Release 0.12.6 of the Amazon Kinesis Producer Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,40 @@ For detailed information and installation instructions, see the article [Develop
 
 ## Release Notes
 
+### 0.12.6
+
+#### C++ Core
+* Added Windows support  
+  The 0.12.x version now supports Windows.  
+  The Windows version is currently mastered on the branch `windows`, which will be merged at a later date.  
+  The build instructions for Windows are currently out of date, and will be updated at a later date.__
+  * [Issue #113](https://github.com/awslabs/amazon-kinesis-producer/issues/113)
+  * [Issue #74](https://github.com/awslabs/amazon-kinesis-producer/issues/74)
+  * [Issue #73](https://github.com/awslabs/amazon-kinesis-producer/issues/73)
+* Removed the libc wrapper  
+  The libc wrapper lowered the required version of glibc.  The KPL is now built with an older version of libc, which removes the need for the wrapper.  
+  * [PR #139](https://github.com/awslabs/amazon-kinesis-producer/pull/139)
+* Set the minimum required version of macOS to 10.9.  
+  The KPL is now built against macOS 10.9.  
+  * [Issue #117](https://github.com/awslabs/amazon-kinesis-producer/issues/117)
+  * [PR #138](https://github.com/awslabs/amazon-kinesis-producer/pull/138)
+
+#### Java
+* Allow exceptions to bubble to the thread exception handler for Daemon threads.  
+  Exceptions that occur on daemon threads will now be allowed to propagate to the thread exception handler.  This doesn't provide any additional monitoring or handling of thread death.  
+  * [PR #112](https://github.com/awslabs/amazon-kinesis-producer/pull/112)
+  * [Issue #111](https://github.com/awslabs/amazon-kinesis-producer/issues/111)
+* Updated `amazon-kinesis-producer-sample` to use the correct properties in its configuration file.  
+  * [PR #120](https://github.com/awslabs/amazon-kinesis-producer/pull/120)
+  * [Issue #119](https://github.com/awslabs/amazon-kinesis-producer/issues/119)
+* Updated documentation of `AggregationMaxSize` to match actual Kinesis limits.  
+  * [PR #133](https://github.com/awslabs/amazon-kinesis-producer/pull/133)
+* Added support for setting `ThreadingModel`, and `ThreadPoolSize` using a properties file.  
+  * [PR #134](https://github.com/awslabs/amazon-kinesis-producer/pull/134)
+  * [Issue #124](https://github.com/awslabs/amazon-kinesis-producer/issues/124)
+* Extracted `IKinesisProducer` from `KinesisProducer` to allow for easier testing.  
+  * [PR #136](https://github.com/awslabs/amazon-kinesis-producer/pull/136)
+
 ### 0.12.5
 
 #### C++ Core

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -36,7 +36,7 @@ struct EndpointConfiguration {
     kinesis_endpoint_(kinesis_endpoint), cloudwatch_endpoint_(cloudwatch_endpoint) {}
 };
 
-const constexpr char* kVersion = "0.12.4";
+const constexpr char* kVersion = "0.12.6N";
 const std::unordered_map< std::string, EndpointConfiguration > kRegionEndpointOverride = {
   { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } }
 };

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.12.5</version>
+            <version>0.12.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.6-SNAPSHOT</version>
+    <version>0.12.6</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>


### PR DESCRIPTION
* Added Windows support
  The 0.12.x version now supports Windows.
  The Windows version is currently mastered on the branch `windows`, which will be merged at a later date.
  The build instructions for Windows are currently out of date, and will be updated at a later date.__
  * Issue #113
  * Issue #74
  * Issue #73
* Removed the libc wrapper
  The libc wrapper lowered the required version of glibc.  The KPL is now built with an older version of libc, which removes the need for the wrapper.
  * PR #139
* Set the minimum required version of macOS to 10.9.
  The KPL is now built against macOS 10.9.
  * Issue #117
  * PR #138

* Allow exceptions to bubble to the thread exception handler for Daemon threads.
  Exceptions that occur on daemon threads will now be allowed to propagate to the thread exception handler.  This doesn't provide any additional monitoring or handling of thread death.
  * PR #112
  * Issue #111
* Updated `amazon-kinesis-producer-sample` to use the correct properties in its configuration file.
  * PR #120
  * Issue #119
* Updated documentation of `AggregationMaxSize` to match actual Kinesis limits.
  * PR #133
* Added support for setting `ThreadingModel`, and `ThreadPoolSize` using a properties file.
  * PR #134
  * Issue #124
* Extracted `IKinesisProducer` from `KinesisProducer` to allow for easier testing.
  * PR #136