### PR TITLE
Advance Version, and Fix File Age Registration for Certificates

### DIFF
--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -36,7 +36,7 @@ struct EndpointConfiguration {
     kinesis_endpoint_(kinesis_endpoint), cloudwatch_endpoint_(cloudwatch_endpoint) {}
 };
 
-const constexpr char* kVersion = "0.12.7N";
+const constexpr char* kVersion = "0.12.8N";
 const std::unordered_map< std::string, EndpointConfiguration > kRegionEndpointOverride = {
   { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } }
 };

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.7</version>
+    <version>0.12.8-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/CertificateExtractor.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/CertificateExtractor.java
@@ -104,6 +104,7 @@ class CertificateExtractor {
             File destinationCertificate = new File(destinationPath, certificate);
             log.debug("Extracting certificate '{}' to '{}'", certificate, destinationCertificate);
             byte[] certificateData = IOUtils.toByteArray(certificateSource);
+            extractedCertificates.add(destinationCertificate.getAbsoluteFile());
             if (destinationCertificate.exists()) {
                 byte[] existingData = Files.readAllBytes(destinationCertificate.toPath());
                 if (Arrays.equals(certificateData, existingData)) {
@@ -114,36 +115,6 @@ class CertificateExtractor {
             }
             Files.write(destinationCertificate.toPath(), certificateData, StandardOpenOption.WRITE,
                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-            extractedCertificates.add(destinationCertificate.getAbsoluteFile());
-        }
-    }
-
-    private class VerifyingVisitor extends SimpleFileVisitor<Path> {
-
-        private final Path destinationPath;
-
-        private VerifyingVisitor(Path destinationPath) {
-            this.destinationPath = destinationPath;
-        }
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-            if (attrs.isRegularFile()) {
-                Path destination = new File(destinationPath.toFile(), file.getFileName().toString()).toPath();
-                log.debug("Extracting certificate '{}' to '{}'", file.getFileName(), destination);
-                byte[] certificateData = Files.readAllBytes(file);
-                if (Files.exists(destination)) {
-                    byte[] existingData = Files.readAllBytes(destination);
-                    if (certificateData.length == existingData.length && Arrays.equals(certificateData, existingData)) {
-                        log.debug("Certificate '{}' already exists, and content matches. Skipping", file.getFileName());
-                        return FileVisitResult.CONTINUE;
-                    }
-                    log.info("Certificate '{}' already exists, but the content doesn't match. Overwriting", file.getFileName());
-                }
-                Files.copy(file, destination, StandardCopyOption.REPLACE_EXISTING);
-                extractedCertificates.add(destination.toFile().getAbsoluteFile());
-            }
-            return FileVisitResult.CONTINUE;
         }
     }
 }


### PR DESCRIPTION
The certificates weren't properly being registered for file age
management if they already exists.  This now ensures that certificates
are registered correctly.