### PR TITLE
Load binary in chunks to prevent JVM OOME

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -25,9 +25,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileLock;
 import java.nio.file.Paths;
-import java.security.MessageDigest;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,8 +37,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
-import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -873,11 +869,12 @@ public class KinesisProducer implements IKinesisProducer {
                     
                     String extension = os.equals("windows") ? ".exe" : "";
                     String executableName = "kinesis_producer" + extension;
-                    byte[] bin = IOUtils.toByteArray(
-                            this.getClass().getClassLoader().getResourceAsStream(root + "/" + os + "/" + executableName));
-                    MessageDigest md = MessageDigest.getInstance("SHA1");
-                    String mdHex = DatatypeConverter.printHexBinary(md.digest(bin)).toLowerCase();
-                    
+
+                    String mdHex;
+                    try (InputStream binaryInputStream = getBinaryInputStream(root, os, executableName)) {
+                        mdHex = StreamUtil.getMD5(binaryInputStream);
+                    }
+
                     pathToExecutable = Paths.get(pathToTmpDir, "kinesis_producer_" + mdHex + extension).toString();
                     File extracted = new File(pathToExecutable);
                     watchFiles.add(extracted);
@@ -886,22 +883,18 @@ public class KinesisProducer implements IKinesisProducer {
                     final String pathToLock = Paths.get(pathToTmpDir, "kinesis_producer_" + mdHex + ".lock").toString();
                     final File lockFile = new File(pathToLock);
                     try (FileOutputStream lockFOS = new FileOutputStream(lockFile);
-                         FileLock lock = lockFOS.getChannel().lock()) {
+                         FileLock lock = lockFOS.getChannel().lock();
+                         InputStream binaryInputStream = getBinaryInputStream(root, os, executableName)) {
                         if (extracted.exists()) {
-                            boolean contentEqual = false;
-                            if (extracted.length() == bin.length) {
-                                try (InputStream executableIS = new FileInputStream(extracted)) {
-                                    byte[] existingBin = IOUtils.toByteArray(executableIS);
-                                    contentEqual = Arrays.equals(bin, existingBin);
+                            try (InputStream executableIS = new FileInputStream(extracted)) {
+                                if (!StreamUtil.compareStreamsChunked(binaryInputStream, executableIS)) {
+                                    throw new SecurityException("The contents of the binary " + extracted.getAbsolutePath()
+                                                                        + " is not what it's expected to be.");
                                 }
-                            }
-                            if (!contentEqual) {
-                                throw new SecurityException("The contents of the binary " + extracted.getAbsolutePath()
-                                        + " is not what it's expected to be.");
                             }
                         } else {
                             try (OutputStream fos = new FileOutputStream(extracted)) {
-                                IOUtils.write(bin, fos);
+                                IOUtils.copyLarge(binaryInputStream, fos);
                             }
                             extracted.setExecutable(true);
                         }
@@ -921,5 +914,9 @@ public class KinesisProducer implements IKinesisProducer {
 
             }
         }
+    }
+
+    private InputStream getBinaryInputStream(String root, String os, String executableName) {
+        return this.getClass().getClassLoader().getResourceAsStream(root + "/" + os + "/" + executableName);
     }
 }

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/StreamUtil.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/StreamUtil.java
@@ -1,0 +1,56 @@
+package com.amazonaws.services.kinesis.producer;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+
+/**
+ * Utility to perform stream operations using chunks to save on JVM memory.
+ */
+public class StreamUtil {
+
+    private static final int CHUNK_SIZE = 64 * 1024;
+
+    public static boolean compareStreamsChunked(InputStream stream1, InputStream stream2) throws IOException {
+        byte[] stream1Chunk = new byte[CHUNK_SIZE];
+        byte[] stream2Chunk = new byte[CHUNK_SIZE];
+        try {
+            DataInputStream stream2DataStream = new DataInputStream(stream2);
+            int len;
+            while ((len = stream1.read(stream1Chunk)) > 0) {
+                // readFully guarantees we read the same number of bytes
+                // that were just read from stream 1.
+                // EOFException is thrown if we are past the end of stream2.
+                stream2DataStream.readFully(stream2Chunk, 0, len);
+                for (int i = 0; i < len; i++) {
+                    if (stream1Chunk[i] != stream2Chunk[i]) {
+                        return false;
+                    }
+                }
+            }
+
+            // If the second stream has been completely consumed at this point
+            // we know the streams are identical.
+            return stream2.read() < 0;
+        } catch (EOFException ioe) {
+            // We reached the end of stream 2 before the end of stream 1
+            // indicating the streams are not identical.
+            return false;
+        }
+    }
+
+    public static String getMD5(InputStream stream) throws Exception {
+        byte[] buffer = new byte[CHUNK_SIZE];
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        DigestInputStream dis = new DigestInputStream(stream, md);
+
+        // Read the entire stream to be able to generate the MD5
+        while (dis.read(buffer) != -1) {}
+
+        return DatatypeConverter.printHexBinary(md.digest()).toLowerCase();
+    }
+}

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/StreamUtilTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/StreamUtilTest.java
@@ -1,0 +1,43 @@
+package com.amazonaws.services.kinesis.producer;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+import static com.amazonaws.util.ClassLoaderHelper.getResourceAsStream;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StreamUtilTest {
+
+    @Test
+    public void testSuccessfulStreamComparison() throws Exception {
+        InputStream stream1 = getResourceAsStream("stream1.txt");
+        InputStream stream2 = getResourceAsStream("stream1.txt");
+        assertTrue(StreamUtil.compareStreamsChunked(stream1, stream2));
+    }
+
+    @Test
+    public void testFailedStreamComparison() throws Exception {
+        InputStream stream1 = getResourceAsStream("stream1.txt");
+        InputStream stream2 = getResourceAsStream("stream1Truncated.txt");
+        assertFalse(StreamUtil.compareStreamsChunked(stream1, stream2));
+    }
+
+    @Test
+    public void testStreamMD5Creation() throws Exception {
+        InputStream stream = getResourceAsStream("stream1.txt");
+        String chunkedStreamMD5 = StreamUtil.getMD5(stream);
+
+        byte[] bin = IOUtils.toByteArray(getResourceAsStream("stream1.txt"));
+        MessageDigest md = MessageDigest.getInstance("SHA1");
+        String byteMD5 = DatatypeConverter.printHexBinary(md.digest(bin)).toLowerCase();
+
+        assertEquals(chunkedStreamMD5, byteMD5);
+    }
+
+}

--- a/java/amazon-kinesis-producer/src/test/resources/stream1.txt
+++ b/java/amazon-kinesis-producer/src/test/resources/stream1.txt
@@ -1,0 +1,49 @@
+Informally speaking, a data stream is a sequence of data that is too large to be
+stored in available memory. The data may be a sequence of numbers, points,
+edges in a graph, and so on. There are many examples of data streams, such as
+internet search logs, network traffic, sensor networks, and scientific data streams
+(such as in astronomics, genomics, physical simulations, etc.). The abundance of
+data streams has led to new algorithmic paradigms for processing them, which
+often impose very stringent requirements on the algorithm’s resources.
+Formally, in the streaming model, there is a sequence of elements a1, . . . , am
+presented to an algorithm, where each element is drawn from a universe [n] =
+{1, . . . , n}. The algorithm is allowed a single or a small number of passes over
+the stream. In network applications, the algorithm is typically only given a single
+pass, since if data on a network is not physically stored somewhere, it may be
+impossible to make a second pass over it. In other applications, such as when data
+resides on external memory, it may be streamed through main memory a small
+number of times, each time constituting a pass of the algorithm.
+The algorithm would like to compute a function or relation of the data stream.
+Because of the sheer size, for many interesting problems the algorithm is necessarily
+randomized and approximate in order to be efficient. One should note that
+the randomness is in the random coin tosses of the algorithm rather than in the
+stream. That is, with high probability over the coin tosses of the algorithm, the
+algorithm should correctly compute the function or relation for any stream that is
+presented to it. This is more robust than say, if the algorithm assumed particular
+orderings of the stream that could make the problem easier to solve.
+In this survey we focus on computing or approximating order-independent
+functions f(a1, . . . , am). A function is order-independent if applying any permutation
+to its inputs results in the same function value. As we will see, this is often
+the case in numerical applications, such as if one is interested in the number of
+distinct values in the sequence a1, . . . , am.
+One of the main goals of a streaming algorithm is to use as little memory
+as possible in order to compute or approximate the function of interest. The
+amount of memory used (in bits) is referred to as the space complexity of the
+algorithm. While it is always possible for the algorithm to store the entire sequence
+a1, . . . , am, this is usually extremely prohibitive in applications. For example,
+internet routers often have limited resources; asking them to store a massive
+sequence of network traffic is infeasible. Another goal of streaming algorithms
+is their processing time, i.e., how often it takes to update their memory contents
+when presented with a new item in the stream. Often items in streams are presented
+at very high speeds and the algorithm needs to quickly update the data
+structures in its memory in order to be ready to process future updates.
+For order-independent functions, we can think of the stream as an evolution
+of an underlying vector x ∈ R
+n
+. That is, x is initialized to the all zero vector, and
+when the item i appears in the stream, x undergoes the update
+xi ← xi + 1,
+that is, the items i are associated with coordinates of x, and insertions of items
+cause additive updates to x. The goal when computing an order-independent function
+f is to compute (or approximate with high probability) f(x), where x is the
+vector at the end of the stream after all insertions have been performed.

--- a/java/amazon-kinesis-producer/src/test/resources/stream1Truncated.txt
+++ b/java/amazon-kinesis-producer/src/test/resources/stream1Truncated.txt
@@ -1,0 +1,28 @@
+Informally speaking, a data stream is a sequence of data that is too large to be
+stored in available memory. The data may be a sequence of numbers, points,
+edges in a graph, and so on. There are many examples of data streams, such as
+internet search logs, network traffic, sensor networks, and scientific data streams
+(such as in astronomics, genomics, physical simulations, etc.). The abundance of
+data streams has led to new algorithmic paradigms for processing them, which
+often impose very stringent requirements on the algorithm’s resources.
+Formally, in the streaming model, there is a sequence of elements a1, . . . , am
+presented to an algorithm, where each element is drawn from a universe [n] =
+{1, . . . , n}. The algorithm is allowed a single or a small number of passes over
+the stream. In network applications, the algorithm is typically only given a single
+pass, since if data on a network is not physically stored somewhere, it may be
+impossible to make a second pass over it. In other applications, such as when data
+resides on external memory, it may be streamed through main memory a small
+number of times, each time constituting a pass of the algorithm.
+The algorithm would like to compute a function or relation of the data stream.
+Because of the sheer size, for many interesting problems the algorithm is necessarily
+randomized and approximate in order to be efficient. One should note that
+the randomness is in the random coin tosses of the algorithm rather than in the
+stream. That is, with high probability over the coin tosses of the algorithm, the
+algorithm should correctly compute the function or relation for any stream that is
+presented to it. This is more robust than say, if the algorithm assumed particular
+orderings of the stream that could make the problem easier to solve.
+In this survey we focus on computing or approximating order-independent
+functions f(a1, . . . , am). A function is order-independent if applying any permutation
+to its inputs results in the same function value. As we will see, this is often
+the case in numerical applications, such as if one is interested in the number of
+distinct values in the sequence a1, . . . , am.


### PR DESCRIPTION
We use KPL in some of our micro-services where the JVM only has 256 mb allocated to it. 

The way the KinesisProducer is written, it reads the entire binary into memory. This results in our micro-services hitting OutOfMemoryError exceptions.  

We are currently working around this issue by loading the binary into memory in chunks both for the MD5 calculation as well as the comparison with any potentially pre-existing binaries.  This PR contains the implementation we are using in production that we would love to get merged into the mainline repository to make upgrades easier in the future. 