### PR TITLE
Remove spin lock from credentials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-L${THIRD_PARTY_LIB_DIR} ${ADDL_LINK_CONFIG}")
 
 set(SOURCE_FILES
         aws/auth/mutable_static_creds_provider.h
+        aws/auth/mutable_static_creds_provider.cc
         aws/kinesis/core/aggregator.h
         aws/kinesis/core/attempt.h
         aws/kinesis/core/collector.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,24 +85,25 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    aws/utils/test/concurrent_hash_map_test.cc
-    aws/utils/test/concurrent_linked_queue_test.cc
-    aws/utils/test/spin_lock_test.cc
-    aws/utils/test/token_bucket_test.cc
-    aws/kinesis/core/test/aggregator_test.cc
-    aws/kinesis/core/test/ipc_manager_test.cc
-    aws/kinesis/core/test/kinesis_record_test.cc
-    aws/kinesis/core/test/limiter_test.cc
-    aws/kinesis/core/test/put_records_request_test.cc
-    aws/kinesis/core/test/reducer_test.cc
-    aws/kinesis/core/test/retrier_test.cc
-    aws/kinesis/core/test/shard_map_test.cc
-    aws/kinesis/core/test/test_utils.cc
-    aws/kinesis/core/test/test_utils.h
-    aws/kinesis/core/test/user_record_test.cc
-    aws/metrics/test/accumulator_test.cc
-    aws/metrics/test/metric_test.cc
-    aws/metrics/test/metrics_manager_test.cc
+    # aws/utils/test/concurrent_hash_map_test.cc
+    # aws/utils/test/concurrent_linked_queue_test.cc
+    # aws/utils/test/spin_lock_test.cc
+    # aws/utils/test/token_bucket_test.cc
+    # aws/kinesis/core/test/aggregator_test.cc
+    # aws/kinesis/core/test/ipc_manager_test.cc
+    # aws/kinesis/core/test/kinesis_record_test.cc
+    # aws/kinesis/core/test/limiter_test.cc
+    # aws/kinesis/core/test/put_records_request_test.cc
+    # aws/kinesis/core/test/reducer_test.cc
+    # aws/kinesis/core/test/retrier_test.cc
+    # aws/kinesis/core/test/shard_map_test.cc
+    # aws/kinesis/core/test/test_utils.cc
+    # aws/kinesis/core/test/test_utils.h
+    # aws/kinesis/core/test/user_record_test.cc
+    # aws/metrics/test/accumulator_test.cc
+    # aws/metrics/test/metric_test.cc
+    # aws/metrics/test/metrics_manager_test.cc
+    aws/auth/test/mutable_static_creds_provider_test.cc
     )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,13 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options("-fpermissive")
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES DEBUG)
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    add_definitions(-DDEBUG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
     if (CMAKE_COMPILER_IS_GNUCXX)
         set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
     endif (CMAKE_COMPILER_IS_GNUCXX)
-endif(CMAKE_BUILD_TYPE MATCHES DEBUG)
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9")
@@ -85,26 +86,25 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    # aws/utils/test/concurrent_hash_map_test.cc
-    # aws/utils/test/concurrent_linked_queue_test.cc
-    # aws/utils/test/spin_lock_test.cc
-    # aws/utils/test/token_bucket_test.cc
-    # aws/kinesis/core/test/aggregator_test.cc
-    # aws/kinesis/core/test/ipc_manager_test.cc
-    # aws/kinesis/core/test/kinesis_record_test.cc
-    # aws/kinesis/core/test/limiter_test.cc
-    # aws/kinesis/core/test/put_records_request_test.cc
-    # aws/kinesis/core/test/reducer_test.cc
-    # aws/kinesis/core/test/retrier_test.cc
-    # aws/kinesis/core/test/shard_map_test.cc
-    # aws/kinesis/core/test/test_utils.cc
-    # aws/kinesis/core/test/test_utils.h
-    # aws/kinesis/core/test/user_record_test.cc
-    # aws/metrics/test/accumulator_test.cc
-    # aws/metrics/test/metric_test.cc
-    # aws/metrics/test/metrics_manager_test.cc
-    aws/auth/test/mutable_static_creds_provider_test.cc
-    )
+    aws/utils/test/concurrent_hash_map_test.cc
+    aws/utils/test/concurrent_linked_queue_test.cc
+    aws/utils/test/spin_lock_test.cc
+    aws/utils/test/token_bucket_test.cc
+    aws/kinesis/core/test/aggregator_test.cc
+    aws/kinesis/core/test/ipc_manager_test.cc
+    aws/kinesis/core/test/kinesis_record_test.cc
+    aws/kinesis/core/test/limiter_test.cc
+    aws/kinesis/core/test/put_records_request_test.cc
+    aws/kinesis/core/test/reducer_test.cc
+    aws/kinesis/core/test/retrier_test.cc
+    aws/kinesis/core/test/shard_map_test.cc
+    aws/kinesis/core/test/test_utils.cc
+    aws/kinesis/core/test/test_utils.h
+    aws/kinesis/core/test/user_record_test.cc
+    aws/metrics/test/accumulator_test.cc
+    aws/metrics/test/metric_test.cc
+    aws/metrics/test/metrics_manager_test.cc
+    aws/auth/test/mutable_static_creds_provider_test.cc)
 
 
 set(THIRD_PARTY_LIBS third_party/lib)

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -62,7 +62,7 @@ void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, 
   current_.updating_ = false;
 }
 
-bool MutableStaticCredentialsProvider::optimistic_read(Aws::Auth::AWSCredentials& destination) {
+bool MutableStaticCredentialsProvider::try_optimistic_read(Aws::Auth::AWSCredentials& destination) {
   //
   // This is an attempt to do an optimistic read.  We assume that the contents of the
   // credentials may change in while copying to the result.
@@ -130,7 +130,7 @@ Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() 
 
   Aws::Auth::AWSCredentials result;
 
-  if (!optimistic_read(result)) {
+  if (!try_optimistic_read(result)) {
     //
     // The optimistic read failed, so just give up and use the lock to acquire the credentials.
     //

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -36,13 +36,12 @@ void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, 
   std::size_t next_slot = (current_slot_ + 1) % slots_.size();
 
   VersionedCredentials* next_creds = &slots_[next_slot];
-  next_creds->version_++;
+  next_creds->updating_ = true;
   next_creds->creds_.SetAWSAccessKeyId(akid);
-  next_creds->version_++;
   next_creds->creds_.SetAWSSecretKey(sk);
-  next_creds->version_++;
   next_creds->creds_.SetSessionToken(token);
   next_creds->version_++;
+  next_creds->updating_ = false;
 
   current_slot_ = next_slot;
   
@@ -66,6 +65,13 @@ Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() 
       std::size_t slot = current_slot_.load();
 
       VersionedCredentials* creds = &slots_[slot];
+      if (creds->updating_) {
+        //
+        // The credentials are currently being updated.  It's not safe to read so
+        // spin while we wait for them to clear
+        //
+        continue;
+      }
       std::uint64_t starting_version = creds->version_.load();
 
       //
@@ -73,8 +79,26 @@ Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() 
       //
       result = creds->creds_;
 
+      if (creds->updating_) {
+        //
+        // The credentials object started to be updated possibly while we were
+        // copying it, so discard what we have and try again.
+        //
+        continue;
+      }
+      
       std::uint64_t ending_version = creds->version_.load();
-  } while (starting_version != ending_version);
+
+      if (starting_version != ending_version) {
+        //
+        // The version changed in between the start of the copy, and the end
+        // of the copy.  We can no longer trust that the resulting copy is
+        // correct.  So we give up and try again.
+        //
+        continue;
+      }
+      return result;
+  } while (true);
 
   return result;
 }

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -1,0 +1,81 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "mutable_static_creds_provider.h"
+#include <limits>
+
+namespace {
+  thread_local Aws::Auth::AWSCredentials* current_credentials = nullptr;
+}
+
+using namespace aws::auth;
+
+MutableStaticCredentialsProvider::MutableStaticCredentialsProvider(const std::string& akid,
+                                                                   const std::string& sk,
+                                                                   std::string token)
+  : current_slot_(0) {
+  Aws::Auth::AWSCredentials creds(akid, sk, token);
+  
+  slots_[0].creds_ = creds;
+    
+}
+
+void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, const std::string& sk, std::string token) {
+  std::lock_guard<std::mutex> lock(update_mutex_);
+
+  std::size_t next_slot = (current_slot_ + 1) % slots_.size();
+
+  VersionedCredentials* next_creds = &slots_[next_slot];
+  next_creds->version_++;
+  next_creds->creds_.SetAWSAccessKeyId(akid);
+  next_creds->version_++;
+  next_creds->creds_.SetAWSSecretKey(sk);
+  next_creds->version_++;
+  next_creds->creds_.SetSessionToken(token);
+  next_creds->version_++;
+
+  current_slot_ = next_slot;
+  
+}
+
+Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() {
+
+
+  Aws::Auth::AWSCredentials result;
+  //
+  // This is an attempt to do an optimistic read.  We assume that the contents of the
+  // credentials are unlikely to change in between a read especially since the slots
+  // constantly move forward.  So we start to read, and after the read see if the
+  // version changed.  Versions advance at the start of the modification, and after each
+  // mutation step.  If we see a version mismatch we try again.  This shouldn't hit
+  // that often, since cereds don't change that much.
+  //
+
+  std::uint64_t starting_version = 0, ending_version = 0;
+  do {
+      std::size_t slot = current_slot_.load();
+
+      VersionedCredentials* creds = &slots_[slot];
+      std::uint64_t starting_version = creds->version_.load();
+
+      //
+      // Should trigger trivial copy
+      //
+      result = creds->creds_;
+
+      std::uint64_t ending_version = creds->version_.load();
+  } while (starting_version != ending_version);
+
+  return result;
+}
+

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -37,6 +37,7 @@ class MutableStaticCredentialsProvider
   struct VersionedCredentials {
     Aws::Auth::AWSCredentials creds_;
     std::atomic<std::uint64_t> version_;
+    std::atomic<bool> updating_;
     VersionedCredentials() : version_(0) {}
   };
   std::array<VersionedCredentials, 10> slots_;

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -30,9 +30,10 @@ struct DebugStats {
   std::uint64_t success_;
   std::uint64_t retried_;
   std::uint64_t attempts_;
+  std::uint64_t used_lock_;
 
   DebugStats() : update_before_load_(0), update_after_load_(0), version_mismatch_(0),
-                 success_(0), retried_(0), attempts_(0) {}
+                 success_(0), retried_(0), attempts_(0), used_lock_(0) {}
 };
 
 // Like basic static creds, but with an atomic set operation
@@ -58,6 +59,8 @@ class MutableStaticCredentialsProvider
   VersionedCredentials current_;
 
   std::mutex update_mutex_;
+
+  bool optimistic_read(Aws::Auth::AWSCredentials& destination);
 
 };
 

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -22,6 +22,18 @@
 
 namespace aws {
 namespace auth {
+
+  struct DebugStats {
+    std::uint64_t update_before_load_;
+    std::uint64_t update_after_load_;
+    std::uint64_t version_mismatch_;
+    std::uint64_t success_;
+    std::uint64_t retried_;
+    std::uint64_t attempts_;
+
+    DebugStats() : update_before_load_(0), update_after_load_(0), version_mismatch_(0),
+                   success_(0), retried_(0), attempts_(0) {}
+  };
     
 // Like basic static creds, but with an atomic set operation
 class MutableStaticCredentialsProvider
@@ -33,6 +45,8 @@ class MutableStaticCredentialsProvider
 
   Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
+  DebugStats get_debug_stats();
+
  private:
   struct VersionedCredentials {
     Aws::Auth::AWSCredentials creds_;
@@ -40,8 +54,7 @@ class MutableStaticCredentialsProvider
     std::atomic<bool> updating_;
     VersionedCredentials() : version_(0) {}
   };
-  std::array<VersionedCredentials, 10> slots_;
-  std::atomic<std::size_t> current_slot_;
+  VersionedCredentials current_;
 
   std::mutex update_mutex_;
 

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -23,29 +23,30 @@
 namespace aws {
 namespace auth {
 
-  struct DebugStats {
-    std::uint64_t update_before_load_;
-    std::uint64_t update_after_load_;
-    std::uint64_t version_mismatch_;
-    std::uint64_t success_;
-    std::uint64_t retried_;
-    std::uint64_t attempts_;
+struct DebugStats {
+  std::uint64_t update_before_load_;
+  std::uint64_t update_after_load_;
+  std::uint64_t version_mismatch_;
+  std::uint64_t success_;
+  std::uint64_t retried_;
+  std::uint64_t attempts_;
 
-    DebugStats() : update_before_load_(0), update_after_load_(0), version_mismatch_(0),
-                   success_(0), retried_(0), attempts_(0) {}
-  };
-    
+  DebugStats() : update_before_load_(0), update_after_load_(0), version_mismatch_(0),
+                 success_(0), retried_(0), attempts_(0) {}
+};
+
 // Like basic static creds, but with an atomic set operation
 class MutableStaticCredentialsProvider
     : public Aws::Auth::AWSCredentialsProvider {
  public:
   MutableStaticCredentialsProvider(const std::string& akid, const std::string& sk, std::string token = "");
-  
+
   void set_credentials(const std::string& akid, const std::string& sk, std::string token = "");
 
   Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
   DebugStats get_debug_stats();
+
 
  private:
   struct VersionedCredentials {

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Amazon Software License (the "License").
 // You may not use this file except in compliance with the License.
@@ -15,39 +15,35 @@
 #define AWS_AUTH_MUTABLE_STATIC_CREDS_PROVIDER_H_
 
 #include <aws/core/auth/AWSCredentialsProvider.h>
-#include <aws/utils/spin_lock.h>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <array>
 
 namespace aws {
 namespace auth {
-
+    
 // Like basic static creds, but with an atomic set operation
 class MutableStaticCredentialsProvider
     : public Aws::Auth::AWSCredentialsProvider {
  public:
-  MutableStaticCredentialsProvider(std::string akid,
-                                   std::string sk,
-                                   std::string token = "")
-      : creds_(akid, sk, token) {}
+  MutableStaticCredentialsProvider(const std::string& akid, const std::string& sk, std::string token = "");
+  
+  void set_credentials(const std::string& akid, const std::string& sk, std::string token = "");
 
-  void set_credentials(std::string akid,
-                       std::string sk,
-                       std::string token = "") {
-    Lock lock_(mutex_);
-    creds_.SetAWSAccessKeyId(akid);
-    creds_.SetAWSSecretKey(sk);
-    creds_.SetSessionToken(token);
-  }
-
-  Aws::Auth::AWSCredentials GetAWSCredentials() override {
-    Lock lock_(mutex_);
-    return creds_;
-  }
+  Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
  private:
-  using Mutex = aws::utils::TicketSpinLock;
-  using Lock = std::lock_guard<Mutex>;
-  Mutex mutex_;
-  Aws::Auth::AWSCredentials creds_;
+  struct VersionedCredentials {
+    Aws::Auth::AWSCredentials creds_;
+    std::atomic<std::uint64_t> version_;
+    VersionedCredentials() : version_(0) {}
+  };
+  std::array<VersionedCredentials, 10> slots_;
+  std::atomic<std::size_t> current_slot_;
+
+  std::mutex update_mutex_;
+
 };
 
 } //namespace auth

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -60,7 +60,7 @@ class MutableStaticCredentialsProvider
 
   std::mutex update_mutex_;
 
-  bool optimistic_read(Aws::Auth::AWSCredentials& destination);
+  bool try_optimistic_read(Aws::Auth::AWSCredentials& destination);
 
 };
 

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -1,0 +1,103 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "../mutable_static_creds_provider.h"
+
+#include <chrono>
+#include <thread>
+#include <array>
+#include <vector>
+#include <iomanip>
+#include <cstdint>
+#include <ctime>
+#include <iostream>
+
+#include <boost/test/unit_test.hpp>
+
+struct ResultsCounter {
+  std::uint64_t matched_;
+  std::uint64_t mismatched_;
+  std::uint64_t total_;
+
+  ResultsCounter() :
+    matched_(0), mismatched_(0), total_(0) {}
+
+  void match() {
+    ++matched_;
+    ++total_;
+  }
+
+  void mismatch() {
+    ++mismatched_;
+    ++total_;
+  }
+    
+};
+
+BOOST_AUTO_TEST_SUITE(MutableStaticCredsProviderTest)
+
+BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
+  const std::uint32_t kReaderThreadCount = 20;
+  std::atomic<bool> test_running(true);
+  std::array<ResultsCounter, kReaderThreadCount> results;
+  std::vector<std::thread> reader_threads;
+
+  aws::auth::MutableStaticCredentialsProvider provider("initial-0", "initial-0", "initial-0");
+    
+
+  std::thread producer_thread([&] {
+      using namespace std::chrono;
+      auto start = system_clock::now();
+      auto end = start + 10s;
+      system_clock::time_point now;
+      std::uint32_t counter = 0;
+      do {
+        now = system_clock::now();
+        ++counter;
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1s);
+        std::stringstream ss;
+        std::time_t now_time = system_clock::to_time_t(now);
+        ss << std::put_time(std::gmtime(&now_time), "%FT%T") << "-" << std::setfill('0') << std::setw(10) << counter;
+        std::string value = ss.str();
+        std::cout << "Setting Creds to " << value << std::endl;
+        provider.set_credentials(value, value, value);
+      } while (now < end);
+    });
+
+  for(std::uint32_t i = 0; i < kReaderThreadCount; ++i) {
+    reader_threads.emplace_back([i, &provider, &results, &test_running] {
+        while(test_running) {
+          Aws::Auth::AWSCredentials creds = provider.GetAWSCredentials();
+          if (creds.GetAWSAccessKeyId() != creds.GetAWSSecretKey() && creds.GetAWSSecretKey() != creds.GetSessionToken()) {
+            results[i].mismatch();
+          } else {
+            results[i].match();
+          }
+        }
+      });
+  }
+
+  producer_thread.join();
+  test_running = false;
+
+  std::for_each(reader_threads.begin(), reader_threads.end(), [](std::thread& t) { t.join(); });
+  std::cout << "Results" << std::endl;
+  std::cout << "\t" << std::setw(15) << "Matched" << std::setw(15) << "Mismatched" << std::setw(15) << "Total" << std::endl;
+  std::for_each(results.begin(), results.end(), [](ResultsCounter& c) {
+      std::cout << "\t" << std::setw(15) << c.matched_ << std::setw(15) << c.mismatched_ << std::setw(15) << c.total_ << std::endl;
+    });
+    
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -24,6 +24,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <aws/utils/logging.h>
+
 struct ResultsCounter {
   std::uint64_t matched_;
   std::uint64_t mismatched_;
@@ -42,7 +44,6 @@ struct ResultsCounter {
     ++mismatched_;
     ++total_;
   }
-    
 };
 
 BOOST_AUTO_TEST_SUITE(MutableStaticCredsProviderTest)
@@ -55,7 +56,8 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
   std::vector<std::thread> reader_threads;
 
   aws::auth::MutableStaticCredentialsProvider provider("initial-0", "initial-0", "initial-0");
-    
+
+  LOG(info) << "Starting producer thread";
 
   std::thread producer_thread([&] {
       using namespace std::chrono;
@@ -66,17 +68,16 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
       do {
         now = system_clock::now();
         ++counter;
-        using namespace std::chrono_literals;
-//        std::this_thread::sleep_for(50ms);
         std::stringstream ss;
         std::time_t now_time = system_clock::to_time_t(now);
         ss << std::put_time(std::gmtime(&now_time), "%FT%T") << "-" << std::setfill('0') << std::setw(10) << counter;
         std::string value = ss.str();
-        // std::cout << "Setting Creds to " << value << std::endl;
         provider.set_credentials(value, value, value);
       } while (now < end);
+      LOG(info) << "Producer thread completed";
     });
 
+  LOG(info) << "Starting " << kReaderThreadCount << " consumer threads";
   for(std::uint32_t i = 0; i < kReaderThreadCount; ++i) {
     reader_threads.emplace_back([i, &provider, &results, &test_running, &debug_stats] {
         using namespace std::chrono;
@@ -98,50 +99,55 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
       });
   }
 
+  LOG(info) << "Waiting for producer thread to complete";
   producer_thread.join();
-  test_running = false;
 
+  LOG(info) << "Notifying consumers to exit";
+  test_running = false;
   std::for_each(reader_threads.begin(), reader_threads.end(), [](std::thread& t) { t.join(); });
-  std::cout << "Results" << std::endl;
+  LOG(info) << "All consumers completed";
+  
+  LOG(info) << "Results";
   std::uint32_t results_width = 20;
-  std::cout << "\t"
-            << std::setw(results_width) << "Mabtched"
+  LOG(info) << "\t"
+            << std::setw(results_width) << "Matched"
             << std::setw(results_width) << "Mismatched"
             << std::setw(results_width) << "Total"
-            << std::setw(results_width) << "Calls/s"
-            << std::endl;
-  std::for_each(results.begin(), results.end(), [results_width](ResultsCounter& c) {
+            << std::setw(results_width) << "Calls/s";
+
+  std::uint64_t failures = 0;
+  std::for_each(results.begin(), results.end(), [results_width, &failures](ResultsCounter& c) {
+      failures += c.mismatched_;
       double calls_per = c.total_ / c.seconds_;
-      std::cout << "\t"
+      LOG(info) << "\t"
                 << std::setw(results_width) << c.matched_
                 << std::setw(results_width) << c.mismatched_
                 << std::setw(results_width) << c.total_
-                << std::setw(results_width) << std::setprecision(10) << calls_per
-                << std::endl;
+                << std::setw(results_width) << std::setprecision(10) << calls_per;
     });
-
+#ifdef DEBUG
   std::uint32_t debug_width = 20;
-  std::cout << "Debug Stats" << std::endl;
-  std::cout << "\t"
+  LOG(info) << "Debug Stats" << std::endl;
+  LOG(info) << "\t"
             << std::setw(debug_width) << "Update Before Load"
             << std::setw(debug_width) << "Update After Load"
             << std::setw(debug_width) << "Version Mismatch"
             << std::setw(debug_width) << "Retried"
             << std::setw(debug_width) << "Success"
-            << std::setw(debug_width) << "Total"
-            << std::endl;
+            << std::setw(debug_width) << "Total";
   std::for_each(debug_stats.begin(), debug_stats.end(), [debug_width](aws::auth::DebugStats& d) {
-      std::cout << "\t"
+      LOG(info) << "\t"
                 << std::setw(debug_width) << d.update_before_load_
                 << std::setw(debug_width) << d.update_after_load_
                 << std::setw(debug_width) << d.version_mismatch_
                 << std::setw(debug_width) << d.retried_
                 << std::setw(debug_width) << d.success_
-                << std::setw(debug_width) << d.attempts_
-                << std::endl;
+                << std::setw(debug_width) << d.attempts_;
+
     });
-    
-    
+#endif
+  BOOST_CHECK_EQUAL(failures, 0);
+  LOG(info) << "Test Completed";
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Removed the spin lock from the credentials class.  The spin lock was really expensive and problematic performance wise.  

The new approach uses an optimistic read via an interlocked change process to allow the get method to detect a change and retry the load of the credentials.