### PR TITLE
Ticket spin locks will now devolve to using locks after a specific number of spins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(ADDL_LINK_CONFIG "-static-libstdc++")
     add_compile_options("-fpermissive")
 endif()
-
+add_definitions(-DDEBUG)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DDEBUG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-    if (CMAKE_COMPILER_IS_GNUCXX)
-        set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
-    endif (CMAKE_COMPILER_IS_GNUCXX)
+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    # if (CMAKE_COMPILER_IS_GNUCXX)
+    #     set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
+    # endif (CMAKE_COMPILER_IS_GNUCXX)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(APPLE)
@@ -71,6 +71,7 @@ set(SOURCE_FILES
         aws/utils/io_service_executor.h
         aws/utils/logging.cc
         aws/utils/logging.h
+        aws/utils/spin_lock.cc
         aws/utils/spin_lock.h
         aws/utils/time_sensitive.h
         aws/utils/time_sensitive_queue.h
@@ -86,26 +87,26 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    aws/utils/test/concurrent_hash_map_test.cc
-    aws/utils/test/concurrent_linked_queue_test.cc
+    # aws/utils/test/concurrent_hash_map_test.cc
+    # aws/utils/test/concurrent_linked_queue_test.cc
     aws/utils/test/spin_lock_test.cc
-    aws/utils/test/token_bucket_test.cc
-    aws/kinesis/core/test/aggregator_test.cc
-    aws/kinesis/core/test/ipc_manager_test.cc
-    aws/kinesis/core/test/kinesis_record_test.cc
-    aws/kinesis/core/test/limiter_test.cc
-    aws/kinesis/core/test/put_records_request_test.cc
-    aws/kinesis/core/test/reducer_test.cc
-    aws/kinesis/core/test/retrier_test.cc
-    aws/kinesis/core/test/shard_map_test.cc
-    aws/kinesis/core/test/test_utils.cc
-    aws/kinesis/core/test/test_utils.h
-    aws/kinesis/core/test/user_record_test.cc
-    aws/metrics/test/accumulator_test.cc
-    aws/metrics/test/metric_test.cc
-    aws/metrics/test/metrics_manager_test.cc
-    aws/auth/test/mutable_static_creds_provider_test.cc)
-
+    # aws/utils/test/token_bucket_test.cc
+    # aws/kinesis/core/test/aggregator_test.cc
+    # aws/kinesis/core/test/ipc_manager_test.cc
+    # aws/kinesis/core/test/kinesis_record_test.cc
+    # aws/kinesis/core/test/limiter_test.cc
+    # aws/kinesis/core/test/put_records_request_test.cc
+    # aws/kinesis/core/test/reducer_test.cc
+    # aws/kinesis/core/test/retrier_test.cc
+    # aws/kinesis/core/test/shard_map_test.cc
+    # aws/kinesis/core/test/test_utils.cc
+    # aws/kinesis/core/test/test_utils.h
+    # aws/kinesis/core/test/user_record_test.cc
+    # aws/metrics/test/accumulator_test.cc
+    # aws/metrics/test/metric_test.cc
+    # aws/metrics/test/metrics_manager_test.cc
+    # aws/auth/test/mutable_static_creds_provider_test.cc)
+)
 
 set(THIRD_PARTY_LIBS third_party/lib)
 set(THIRD_PARTY_INCLUDE third_party/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(ADDL_LINK_CONFIG "-static-libstdc++")
     add_compile_options("-fpermissive")
 endif()
-add_definitions(-DDEBUG)
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DDEBUG)
-    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-    # if (CMAKE_COMPILER_IS_GNUCXX)
-    #     set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
-    # endif (CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        set(ADDL_LINK_CONFIG "${ADDL_LINK_CONFIG} -static-libasan")
+    endif (CMAKE_COMPILER_IS_GNUCXX)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(APPLE)
@@ -87,25 +87,25 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    # aws/utils/test/concurrent_hash_map_test.cc
-    # aws/utils/test/concurrent_linked_queue_test.cc
+    aws/utils/test/concurrent_hash_map_test.cc
+    aws/utils/test/concurrent_linked_queue_test.cc
     aws/utils/test/spin_lock_test.cc
-    # aws/utils/test/token_bucket_test.cc
-    # aws/kinesis/core/test/aggregator_test.cc
-    # aws/kinesis/core/test/ipc_manager_test.cc
-    # aws/kinesis/core/test/kinesis_record_test.cc
-    # aws/kinesis/core/test/limiter_test.cc
-    # aws/kinesis/core/test/put_records_request_test.cc
-    # aws/kinesis/core/test/reducer_test.cc
-    # aws/kinesis/core/test/retrier_test.cc
-    # aws/kinesis/core/test/shard_map_test.cc
-    # aws/kinesis/core/test/test_utils.cc
-    # aws/kinesis/core/test/test_utils.h
-    # aws/kinesis/core/test/user_record_test.cc
-    # aws/metrics/test/accumulator_test.cc
-    # aws/metrics/test/metric_test.cc
-    # aws/metrics/test/metrics_manager_test.cc
-    # aws/auth/test/mutable_static_creds_provider_test.cc)
+    aws/utils/test/token_bucket_test.cc
+    aws/kinesis/core/test/aggregator_test.cc
+    aws/kinesis/core/test/ipc_manager_test.cc
+    aws/kinesis/core/test/kinesis_record_test.cc
+    aws/kinesis/core/test/limiter_test.cc
+    aws/kinesis/core/test/put_records_request_test.cc
+    aws/kinesis/core/test/reducer_test.cc
+    aws/kinesis/core/test/retrier_test.cc
+    aws/kinesis/core/test/shard_map_test.cc
+    aws/kinesis/core/test/test_utils.cc
+    aws/kinesis/core/test/test_utils.h
+    aws/kinesis/core/test/user_record_test.cc
+    aws/metrics/test/accumulator_test.cc
+    aws/metrics/test/metric_test.cc
+    aws/metrics/test/metrics_manager_test.cc
+    aws/auth/test/mutable_static_creds_provider_test.cc
 )
 
 set(THIRD_PARTY_LIBS third_party/lib)

--- a/aws/utils/spin_lock.cc
+++ b/aws/utils/spin_lock.cc
@@ -1,0 +1,36 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "spin_lock.h"
+
+using namespace aws::utils;
+
+namespace {
+  thread_local TicketSpinLock::DebugStats debug_stats;
+}
+
+void TicketSpinLock::add_acquired() {
+  debug_stats.acquired_count++;
+}
+
+void TicketSpinLock::add_acquired_lock() {
+  debug_stats.acquired_with_lock++;
+}
+
+void TicketSpinLock::add_spin() {
+  debug_stats.total_spins++;
+}
+
+TicketSpinLock::DebugStats TicketSpinLock::get_debug_stats() {
+  return debug_stats;
+}

--- a/aws/utils/spin_lock.cc
+++ b/aws/utils/spin_lock.cc
@@ -14,7 +14,7 @@
 #include "spin_lock.h"
 
 using namespace aws::utils;
-
+#ifdef DEBUG
 namespace {
   thread_local TicketSpinLock::DebugStats debug_stats;
 }
@@ -34,3 +34,4 @@ void TicketSpinLock::add_spin() {
 TicketSpinLock::DebugStats TicketSpinLock::get_debug_stats() {
   return debug_stats;
 }
+#endif

--- a/aws/utils/spin_lock.h
+++ b/aws/utils/spin_lock.h
@@ -81,9 +81,9 @@ class TicketSpinLock : boost::noncopyable {
   inline std::condition_variable& cv_for_ticket(const std::size_t& ticket) noexcept {
     return unlocked_cv_[lock_shard(ticket)];
   }
-  static const std::uint32_t kMaxSpinCount = 1000;
+  static const std::uint32_t kMaxSpinCount = 100;
 
-  static const std::size_t kLockShards = 13;
+  static const std::size_t kLockShards = 31;
   std::array<std::mutex, kLockShards> condition_locks_;
   std::array<std::condition_variable, kLockShards> unlocked_cv_;
   std::atomic<size_t> now_serving_;

--- a/aws/utils/spin_lock.h
+++ b/aws/utils/spin_lock.h
@@ -15,7 +15,10 @@
 #define AWS_UTILS_SPIN_LOCK_H_
 
 #include <atomic>
-
+#include <cstdint>
+#include <mutex>
+#include <condition_variable>
+#include <array>
 #include <boost/noncopyable.hpp>
 
 namespace aws {
@@ -27,22 +30,81 @@ class TicketSpinLock : boost::noncopyable {
       : now_serving_(0),
         next_ticket_(0) {}
 
+#ifdef DEBUG
+  struct DebugStats {
+    std::uint64_t acquired_count;
+    std::uint64_t acquired_with_lock;
+    std::uint64_t total_spins;
+  };
+
+  void add_acquired();
+  void add_acquired_lock();
+  void add_spin();
+
+  DebugStats get_debug_stats();
+#else
+#define add_acquired();
+#define add_acquired_lock();
+#define add_spin();
+#endif
+
+  
   inline void lock() noexcept {
     size_t my_ticket = next_ticket_.fetch_add(1);
-    while (now_serving_ != my_ticket);
+    std::uint32_t spin_count = 0;
+    do {
+      add_spin();
+      spin_count++;
+      if (spin_count > kMaxSpinCount) {
+        std::unique_lock<std::mutex> lock(lock_for_ticket(my_ticket));
+        cv_for_ticket(my_ticket).wait(lock, [this, &my_ticket] { return now_serving_ == my_ticket; });
+        spin_count = 0;
+        add_acquired_lock();
+      }
+    } while (now_serving_ != my_ticket);
+    add_acquired();
   }
 
   inline void unlock() noexcept {
     now_serving_++;
+    std::unique_lock<std::mutex> lock(lock_for_ticket(now_serving_));
+    cv_for_ticket(now_serving_).notify_all();
   }
 
  private:
+  inline std::size_t lock_shard(const std::size_t& ticket) noexcept {
+    return ticket % kLockShards;
+  }
+  inline std::mutex& lock_for_ticket(const std::size_t& ticket) noexcept {
+    return condition_locks_[lock_shard(ticket)];
+  }
+  inline std::condition_variable& cv_for_ticket(const std::size_t& ticket) noexcept {
+    return unlocked_cv_[lock_shard(ticket)];
+  }
+  static const std::uint32_t kMaxSpinCount = 1000;
+
+  static const std::size_t kLockShards = 13;
+  std::array<std::mutex, kLockShards> condition_locks_;
+  std::array<std::condition_variable, kLockShards> unlocked_cv_;
   std::atomic<size_t> now_serving_;
   std::atomic<size_t> next_ticket_;
+
+
 };
 
 class SpinLock : boost::noncopyable {
  public:
+
+#ifdef DEBUG
+  struct DebugStats {
+    std::uint64_t acquired_count;
+    std::uint64_t acquired_with_lock;
+    std::uint64_t total_spins;
+  };
+  DebugStats get_debug_stats() {
+    return DebugStats();
+  }
+#endif
   inline void lock() noexcept {
     while (!try_lock());
   }

--- a/aws/utils/test/spin_lock_test.cc
+++ b/aws/utils/test/spin_lock_test.cc
@@ -87,11 +87,11 @@ void test(const std::string test_name,
 
 BOOST_AUTO_TEST_SUITE(SpinLock)
 
-// BOOST_AUTO_TEST_CASE(SpinLock) {
-//   for (size_t i : {1, 4, 8}) {
-//     test<aws::utils::SpinLock, 100000>("SpinLock", i);
-//   }
-// }
+BOOST_AUTO_TEST_CASE(SpinLock) {
+  for (size_t i : {1, 4, 8}) {
+    test<aws::utils::SpinLock, 100000>("SpinLock", i);
+  }
+}
 
 BOOST_AUTO_TEST_CASE(TicketSpinLock) {
   for (size_t i : {1, 4, 8, 16, 32}) {
@@ -99,10 +99,10 @@ BOOST_AUTO_TEST_CASE(TicketSpinLock) {
   }
 }
 
-// BOOST_AUTO_TEST_CASE(StdMutex) {
-//   for (size_t i : {1, 4, 8}) {
-//     test<aws::mutex, 100000>("std::mutex", i);
-//   }
-// }
+BOOST_AUTO_TEST_CASE(StdMutex) {
+  for (size_t i : {1, 4, 8}) {
+    test<aws::mutex, 100000>("std::mutex", i);
+  }
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The spin lock will now give up after a number of spins, and wait to be notified when it's ticket is available.