### PR TITLE
Extract the native component without copying it into memory

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -77,13 +77,6 @@
             <version>2.6.1</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
-            <optional>true</optional>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
@@ -109,11 +102,27 @@
             <artifactId>confluex-mock-http</artifactId>
             <version>0.4.3</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.2.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -418,7 +418,6 @@ public class Daemon {
     }
     
     private void startChildProcess() throws IOException, InterruptedException {
-        log.info("Asking for trace");
         List<String> args = new ArrayList<>(Arrays.asList(pathToExecutable, "-o", outPipe.getAbsolutePath(), "-i",
                 inPipe.getAbsolutePath(), "-c", protobufToHex(config.toProtobufMessage()), "-k",
                 protobufToHex(makeSetCredentialsMessage(config.getCredentialsProvider(), false)), "-t"));

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -1,9 +1,16 @@
 /*
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License
- * (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
- * http://aws.amazon.com/asl/ or in the "license" file accompanying this file. This file is distributed on an "AS IS"
- * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
+ *  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
  */
 package com.amazonaws.services.kinesis.producer;
 

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License
+ * (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+ * http://aws.amazon.com/asl/ or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.producer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileLock;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.Arrays;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HashedFileCopier {
+    private static final Logger log = LoggerFactory.getLogger(HashedFileCopier.class);
+
+    static final String MESSAGE_DIGEST_ALGORITHM = "SHA-1";
+
+    public static File copyFileFrom(InputStream sourceData, File destinationDirectory, String fileNameFormat)
+            throws Exception {
+        File tempFile = null;
+        try {
+            tempFile = File.createTempFile("kpl", ".tmp", destinationDirectory);
+            log.debug("Extracting file with format {}", fileNameFormat);
+            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+
+            DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream,
+                    MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM));
+            IOUtils.copy(sourceData, digestOutputStream);
+            digestOutputStream.close();
+            byte[] digest = digestOutputStream.getMessageDigest().digest();
+            log.debug("Calculated digest of new file: {}", Arrays.toString(digest));
+            String digestHex = DatatypeConverter.printHexBinary(digest);
+            File finalFile = new File(destinationDirectory, String.format(fileNameFormat, digestHex));
+            File lockFile = new File(destinationDirectory, String.format(fileNameFormat + ".lock", digestHex));
+            log.debug("Preparing to check and copy {} to {}", tempFile.getAbsolutePath(), finalFile.getAbsolutePath());
+            try (FileOutputStream lockFOS = new FileOutputStream(lockFile);
+                    FileLock lock = lockFOS.getChannel().lock()) {
+                if (finalFile.exists() && finalFile.length() == tempFile.length()) {
+                    byte[] existingFileDigest = null;
+                    try (DigestInputStream digestInputStream = new DigestInputStream(new FileInputStream(finalFile),
+                            MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM))) {
+                        byte[] discardedBytes = new byte[8192];
+                        while (digestInputStream.read(discardedBytes) != -1) {
+                            //
+                            // This is just used for the side affect of the digest input stream
+                            //
+                        }
+                        existingFileDigest = digestInputStream.getMessageDigest().digest();
+                    }
+                    if (Arrays.equals(digest, existingFileDigest)) {
+                        //
+                        // The existing file matches the expected file, it's ok to just drop out now
+                        //
+                        log.info("'{}' already exists, and matches.  Not overwriting.", finalFile.getAbsolutePath());
+                        return finalFile;
+                    }
+                    log.warn(
+                            "Detected a mismatch between the existing file, and the new file.  "
+                                    + "Will overwrite the existing file. " + "Existing: {} -- New File: {}",
+                            Arrays.toString(existingFileDigest), Arrays.toString(digest));
+                }
+
+                if (!tempFile.renameTo(finalFile)) {
+                    log.error("Failed to rename '{}' to '{}'", tempFile.getAbsolutePath(), finalFile.getAbsolutePath());
+                    throw new IOException("Failed to rename extracted file");
+                }
+            }
+            return finalFile;
+        } finally {
+            if (tempFile != null && tempFile.exists()) {
+                if (!tempFile.delete()) {
+                    log.warn("Unable to delete temp file: {}", tempFile.getAbsolutePath());
+                }
+            }
+        }
+    }
+}

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -35,12 +35,15 @@ public class HashedFileCopier {
     private static final Logger log = LoggerFactory.getLogger(HashedFileCopier.class);
 
     static final String MESSAGE_DIGEST_ALGORITHM = "SHA-1";
+    static final String TEMP_PREFIX = "kpl";
+    static final String TEMP_SUFFIX = ".tmp";
+    static final String LOCK_SUFFIX = ".lock";
 
     public static File copyFileFrom(InputStream sourceData, File destinationDirectory, String fileNameFormat)
             throws Exception {
         File tempFile = null;
         try {
-            tempFile = File.createTempFile("kpl", ".tmp", destinationDirectory);
+            tempFile = File.createTempFile(TEMP_PREFIX, TEMP_SUFFIX, destinationDirectory);
             log.debug("Extracting file with format {}", fileNameFormat);
             FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
 
@@ -52,7 +55,7 @@ public class HashedFileCopier {
             log.debug("Calculated digest of new file: {}", Arrays.toString(digest));
             String digestHex = DatatypeConverter.printHexBinary(digest);
             File finalFile = new File(destinationDirectory, String.format(fileNameFormat, digestHex));
-            File lockFile = new File(destinationDirectory, String.format(fileNameFormat + ".lock", digestHex));
+            File lockFile = new File(destinationDirectory, String.format(fileNameFormat + LOCK_SUFFIX, digestHex));
             log.debug("Preparing to check and copy {} to {}", tempFile.getAbsolutePath(), finalFile.getAbsolutePath());
             try (FileOutputStream lockFOS = new FileOutputStream(lockFile);
                     FileLock lock = lockFOS.getChannel().lock()) {

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Amazon Software License (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package com.amazonaws.services.kinesis.producer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HashedFileCopierTest {
+
+    private File tempDir;
+
+    @Before
+    public void before() throws Exception {
+        tempDir = File.createTempFile("kpl-unit-tests", "");
+        tempDir.delete();
+        tempDir.mkdirs();
+    }
+
+    @Test
+    public void normalFileCopyTest() throws Exception {
+
+        File resultFile = HashedFileCopier.copyFileFrom(testDataInputStream(), tempDir, "res-file.%s.txt");
+        File expectedFile = new File(tempDir, "res-file." + hexDigestForTestData() + ".txt");
+
+        assertThat(resultFile, equalTo(expectedFile));
+        assertThat(expectedFile.exists(), equalTo(true));
+
+        byte[] writtenBytes = Files.readAllBytes(resultFile.toPath());
+        byte[] expectedBytes = IOUtils.toByteArray(testDataInputStream());
+
+        assertThat(writtenBytes, equalTo(expectedBytes));
+
+    }
+
+    @Test
+    public void fileExistsTest() throws Exception {
+        String executableFormat = "res-file.%s.txt";
+        File expectedFile = new File(tempDir, String.format(executableFormat, hexDigestForTestData()));
+        try (FileOutputStream fso = new FileOutputStream(expectedFile)) {
+            IOUtils.copy(testDataInputStream(), fso);
+        }
+        File resultFile = HashedFileCopier.copyFileFrom(testDataInputStream(), tempDir, executableFormat);
+        assertThat(resultFile, equalTo(expectedFile));
+
+        byte[] expectedData = testDataBytes();
+        byte[] actualData = Files.readAllBytes(resultFile.toPath());
+
+        assertThat(actualData, equalTo(expectedData));
+    }
+
+    @Test
+    public void lengthMismatchTest() throws Exception {
+        String executableFormat = "res-file.%s.txt";
+        File expectedFile = new File(tempDir, String.format(executableFormat, hexDigestForTestData()));
+        FileOutputStream fso = new FileOutputStream(expectedFile);
+        IOUtils.copy(testDataInputStream(), fso);
+        fso.write("This is some extra crap".getBytes(Charset.forName("UTF-8")));
+        fso.close();
+
+        File resultFile = HashedFileCopier.copyFileFrom(testDataInputStream(), tempDir, executableFormat);
+        assertThat(resultFile, equalTo(expectedFile));
+
+        byte[] expectedData = testDataBytes();
+        byte[] actualData = Files.readAllBytes(resultFile.toPath());
+
+        assertThat(actualData, equalTo(expectedData));
+    }
+
+    @Test
+    public void hashMismatchTest() throws Exception {
+        String executableFormat = "res-file.%s.txt";
+        File expectedFile = new File(tempDir, String.format(executableFormat, hexDigestForTestData()));
+        byte[] testData = testDataBytes();
+        testData[10] = (byte)~testData[10];
+
+        Files.write(expectedFile.toPath(), testData);
+
+        File resultFile = HashedFileCopier.copyFileFrom(testDataInputStream(), tempDir, executableFormat);
+        assertThat(resultFile, equalTo(expectedFile));
+
+        byte[] expectedData = testDataBytes();
+        byte[] actualData = Files.readAllBytes(resultFile.toPath());
+
+        assertThat(actualData, equalTo(expectedData));
+    }
+
+    private String hexDigestForTestData() throws Exception {
+        return DatatypeConverter.printHexBinary(hashForTestData());
+    }
+
+    private byte[] testDataBytes() throws Exception {
+        return IOUtils.toByteArray(testDataInputStream());
+    }
+
+    private byte[] hashForTestData() throws Exception {
+        DigestInputStream dis = new DigestInputStream(testDataInputStream(), MessageDigest.getInstance(HashedFileCopier.MESSAGE_DIGEST_ALGORITHM));
+        IOUtils.toByteArray(dis);
+        return dis.getMessageDigest().digest();
+    }
+
+    private InputStream testDataInputStream() {
+        return this.getClass().getClassLoader().getResourceAsStream("test-data/test.txt");
+    }
+}

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -37,9 +37,7 @@ public class HashedFileCopierTest {
 
     @Before
     public void before() throws Exception {
-        tempDir = File.createTempFile("kpl-unit-tests", "");
-        tempDir.delete();
-        tempDir.mkdirs();
+        tempDir = Files.createTempDirectory("kpl-unit-tests").toFile();
     }
 
     @Test

--- a/java/amazon-kinesis-producer/src/test/java/log4j.properties
+++ b/java/amazon-kinesis-producer/src/test/java/log4j.properties
@@ -1,3 +1,0 @@
-log4j.appender.TEST=org.apache.log4j.ConsoleAppender
-log4j.appender.TEST.layout=org.apache.log4j.PatternLayout
-log4j.rootLogger=TRACE, TEST

--- a/java/amazon-kinesis-producer/src/test/resources/logback.xml
+++ b/java/amazon-kinesis-producer/src/test/resources/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~  Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~  Licensed under the Amazon Software License (the "License").
+  ~  You may not use this file except in compliance with the License.
+  ~  A copy of the License is located at
+  ~
+  ~  http://aws.amazon.com/asl/
+  ~
+  ~  or in the "license" file accompanying this file. This file is distributed
+  ~  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  ~  express or implied. See the License for the specific language governing
+  ~  permissions and limitations under the License.
+  -->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} [%mdc{ShardId:-NONE}] - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/java/amazon-kinesis-producer/src/test/resources/test-data/test.txt
+++ b/java/amazon-kinesis-producer/src/test/resources/test-data/test.txt
@@ -1,0 +1,1 @@
+This is a test


### PR DESCRIPTION
Use message digest filter streams to limit the required memory during
native executable extraction.