### PR TITLE
Update the SLF4J dependency version

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.13</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Removing log4j from effectively removed an expected class that is
available in newer versions of SLF4J.  This issue only affected unit
tests, and upgrading to the newer version fixes the unit tests.
