### PR TITLE
Use a shared_ptr and thread_local to store credentials for use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,24 +87,24 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    # aws/utils/test/concurrent_hash_map_test.cc
-    # aws/utils/test/concurrent_linked_queue_test.cc
-    # aws/utils/test/spin_lock_test.cc
-    # aws/utils/test/token_bucket_test.cc
-    # aws/kinesis/core/test/aggregator_test.cc
-    # aws/kinesis/core/test/ipc_manager_test.cc
-    # aws/kinesis/core/test/kinesis_record_test.cc
-    # aws/kinesis/core/test/limiter_test.cc
-    # aws/kinesis/core/test/put_records_request_test.cc
-    # aws/kinesis/core/test/reducer_test.cc
-    # aws/kinesis/core/test/retrier_test.cc
-    # aws/kinesis/core/test/shard_map_test.cc
-    # aws/kinesis/core/test/test_utils.cc
-    # aws/kinesis/core/test/test_utils.h
-    # aws/kinesis/core/test/user_record_test.cc
-    # aws/metrics/test/accumulator_test.cc
-    # aws/metrics/test/metric_test.cc
-    # aws/metrics/test/metrics_manager_test.cc
+    aws/utils/test/concurrent_hash_map_test.cc
+    aws/utils/test/concurrent_linked_queue_test.cc
+    aws/utils/test/spin_lock_test.cc
+    aws/utils/test/token_bucket_test.cc
+    aws/kinesis/core/test/aggregator_test.cc
+    aws/kinesis/core/test/ipc_manager_test.cc
+    aws/kinesis/core/test/kinesis_record_test.cc
+    aws/kinesis/core/test/limiter_test.cc
+    aws/kinesis/core/test/put_records_request_test.cc
+    aws/kinesis/core/test/reducer_test.cc
+    aws/kinesis/core/test/retrier_test.cc
+    aws/kinesis/core/test/shard_map_test.cc
+    aws/kinesis/core/test/test_utils.cc
+    aws/kinesis/core/test/test_utils.h
+    aws/kinesis/core/test/user_record_test.cc
+    aws/metrics/test/accumulator_test.cc
+    aws/metrics/test/metric_test.cc
+    aws/metrics/test/metrics_manager_test.cc
     aws/auth/test/mutable_static_creds_provider_test.cc
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,24 +87,24 @@ if(ENABLE_SEGFAULT_TRIGGER)
 endif(ENABLE_SEGFAULT_TRIGGER)
 
 set(TESTS_SOURCE
-    aws/utils/test/concurrent_hash_map_test.cc
-    aws/utils/test/concurrent_linked_queue_test.cc
-    aws/utils/test/spin_lock_test.cc
-    aws/utils/test/token_bucket_test.cc
-    aws/kinesis/core/test/aggregator_test.cc
-    aws/kinesis/core/test/ipc_manager_test.cc
-    aws/kinesis/core/test/kinesis_record_test.cc
-    aws/kinesis/core/test/limiter_test.cc
-    aws/kinesis/core/test/put_records_request_test.cc
-    aws/kinesis/core/test/reducer_test.cc
-    aws/kinesis/core/test/retrier_test.cc
-    aws/kinesis/core/test/shard_map_test.cc
-    aws/kinesis/core/test/test_utils.cc
-    aws/kinesis/core/test/test_utils.h
-    aws/kinesis/core/test/user_record_test.cc
-    aws/metrics/test/accumulator_test.cc
-    aws/metrics/test/metric_test.cc
-    aws/metrics/test/metrics_manager_test.cc
+    # aws/utils/test/concurrent_hash_map_test.cc
+    # aws/utils/test/concurrent_linked_queue_test.cc
+    # aws/utils/test/spin_lock_test.cc
+    # aws/utils/test/token_bucket_test.cc
+    # aws/kinesis/core/test/aggregator_test.cc
+    # aws/kinesis/core/test/ipc_manager_test.cc
+    # aws/kinesis/core/test/kinesis_record_test.cc
+    # aws/kinesis/core/test/limiter_test.cc
+    # aws/kinesis/core/test/put_records_request_test.cc
+    # aws/kinesis/core/test/reducer_test.cc
+    # aws/kinesis/core/test/retrier_test.cc
+    # aws/kinesis/core/test/shard_map_test.cc
+    # aws/kinesis/core/test/test_utils.cc
+    # aws/kinesis/core/test/test_utils.h
+    # aws/kinesis/core/test/user_record_test.cc
+    # aws/metrics/test/accumulator_test.cc
+    # aws/metrics/test/metric_test.cc
+    # aws/metrics/test/metrics_manager_test.cc
     aws/auth/test/mutable_static_creds_provider_test.cc
 )
 

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -14,25 +14,6 @@
 #include "mutable_static_creds_provider.h"
 #include <limits>
 
-namespace {
-#ifdef DEBUG
-  thread_local aws::auth::DebugStats debug_stats;
-
-  void update_step(std::uint64_t& step, std::uint64_t& outcome) {
-    step++;
-    outcome++;
-    debug_stats.attempts_++;
-  }
-
-  void update_step(std::uint64_t& step) {
-    std::uint64_t ignored = 0;
-    update_step(step, ignored);
-  }
-#else
-#define update_step(...)
-#endif
-}
-
 using namespace aws::auth;
 
 MutableStaticCredentialsProvider::MutableStaticCredentialsProvider(const std::string& akid,
@@ -44,29 +25,14 @@ MutableStaticCredentialsProvider::MutableStaticCredentialsProvider(const std::st
 void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, const std::string& sk, std::string token) {
   std::lock_guard<std::mutex> lock(update_mutex_);
 
-  //
-  // The ordering of stores here is important.  current_.updating_, and current_.version_ are atomics.
-  // Between the two of them they create an interlocked state change that allows consumers
-  // to detect that the credentials have changed during the process of copying the values.
-  //
-  // Specifically current_.version_ must be incremented before current_.updating_ is set to false.
-  // This ensures that consumers will either see a version mismatch or see the updating state change.
-  //
-
   std::shared_ptr<Aws::Auth::AWSCredentials> new_credentials = std::make_shared<Aws::Auth::AWSCredentials>(akid, sk, token);
-
+  Aws::Auth::AWSCredentials new_creds(akid, sk, token);
   std::atomic_store(&creds_, new_credentials);
+//  *creds_ = new_creds;
+//  std::atomic_store(&creds_, new_credentials);
 }
 
 Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() {
   std::shared_ptr<Aws::Auth::AWSCredentials> result = std::atomic_load(&creds_);
   return *result;
-}
-
-DebugStats MutableStaticCredentialsProvider::get_debug_stats() {
-#ifdef DEBUG
-  return debug_stats;
-#else
-  return DebugStats();
-#endif
 }

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -38,8 +38,7 @@ using namespace aws::auth;
 MutableStaticCredentialsProvider::MutableStaticCredentialsProvider(const std::string& akid,
                                                                    const std::string& sk,
                                                                    std::string token) {
-  Aws::Auth::AWSCredentials creds(akid, sk, token);
-  current_.creds_ = creds;
+  creds_ = std::make_shared<Aws::Auth::AWSCredentials>(akid, sk, token);
 }
 
 void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, const std::string& sk, std::string token) {
@@ -54,92 +53,14 @@ void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, 
   // This ensures that consumers will either see a version mismatch or see the updating state change.
   //
 
-  current_.updating_ = true;
-  current_.creds_.SetAWSAccessKeyId(akid);
-  current_.creds_.SetAWSSecretKey(sk);
-  current_.creds_.SetSessionToken(token);
-  current_.version_++;
-  current_.updating_ = false;
-}
+  std::shared_ptr<Aws::Auth::AWSCredentials> new_credentials = std::make_shared<Aws::Auth::AWSCredentials>(akid, sk, token);
 
-bool MutableStaticCredentialsProvider::try_optimistic_read(Aws::Auth::AWSCredentials& destination) {
-  //
-  // This is an attempt to do an optimistic read.  We assume that the contents of the
-  // credentials may change in while copying to the result.
-  //
-  // 1. To handle this we first check if an update is in progress, and if it is we bounce out
-  // and retry.
-  //
-  // 2. If the credential isn't being updated we go ahead and load the current version of
-  // the credential.
-  //
-  // 3. At this point we go ahead and trigger a copy of the credential to the result.  This
-  // is what we will return if our remaining checks indicate everything is still ok.
-  //
-  // 4. We check again to see if the credential has entered updating, if it has it's possible
-  // the version of the credential we copied was split between the two updates.  So we
-  // discard our copy, and try again.
-  //
-  // 5. Finally we make check to see that the version hasn't changed since we started.  This
-  // ensures that the credential didn't enter and exit updates between our update checks.
-  //
-  // If everything is ok we are safe to return the credential, while it may be a nanosecnds
-  // out date it should be fine.
-  //
-
-  if (current_.updating_) {
-    //
-    // The credentials are currently being updated.  It's not safe to read so
-    // spin while we wait for the update to complete.
-    //
-    update_step(debug_stats.update_before_load_, debug_stats.retried_);
-    return false;
-  }
-  std::uint64_t starting_version = current_.version_;
-
-  //
-  // Trigger a trivial copy to the result
-  //
-  destination = current_.creds_;
-
-  if (current_.updating_) {
-    //
-    // The credentials object is being updated and the update may have started while we were
-    // copying it. For safety we discard what we have and try again.
-    //
-    update_step(debug_stats.update_after_load_, debug_stats.retried_);
-    return false;
-  }
-
-  std::uint64_t ending_version = current_.version_;
-
-  if (starting_version != ending_version) {
-    //
-    // The version changed in between the start of the copy, and the end
-    // of the copy.  We can no longer trust that the resulting copy is
-    // correct.  So we discard what we have and try again.
-    //
-    update_step(debug_stats.version_mismatch_, debug_stats.retried_);
-    return false;
-  }
-  update_step(debug_stats.success_);
-  return true;
+  std::atomic_store(&creds_, new_credentials);
 }
 
 Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() {
-
-  Aws::Auth::AWSCredentials result;
-
-  if (!try_optimistic_read(result)) {
-    //
-    // The optimistic read failed, so just give up and use the lock to acquire the credentials.
-    //
-    std::lock_guard<std::mutex> lock(update_mutex_);
-    update_step(debug_stats.used_lock_, debug_stats.success_);
-    result = current_.creds_;
-  }
-
-  return result;
+  std::shared_ptr<Aws::Auth::AWSCredentials> result = std::atomic_load(&creds_);
+  return *result;
 }
 
 DebugStats MutableStaticCredentialsProvider::get_debug_stats() {

--- a/aws/auth/mutable_static_creds_provider.cc
+++ b/aws/auth/mutable_static_creds_provider.cc
@@ -39,6 +39,11 @@ void MutableStaticCredentialsProvider::set_credentials(const std::string& akid, 
 
   std::uint64_t next_version = version_ + 1;
 
+  //
+  // Since the credentials are created with the expected next version, and the entire update
+  // is protected by a lock we can't get into a scenario where one of the consumers has
+  // a mismatched version and credentials.  
+  //
   std::shared_ptr<VersionedCredentials> new_credentials = std::make_shared<VersionedCredentials>(next_version, akid, sk, token);
 
   //
@@ -57,6 +62,13 @@ Aws::Auth::AWSCredentials MutableStaticCredentialsProvider::GetAWSCredentials() 
   //
   // Check to see if the credentials have been updated.  If they have load the credentials
   // and update the thread local.
+  //
+  // If the credentials are changing rapidly it's possible that the thread will read an
+  // old version of the credentials.  Should that occur the next read will update to the
+  // most current version.
+  //
+  // This check still works in the very unlikely event that the next_version value
+  // wraps around.  
   //
   if (current_creds.version_ != version_) {
     std::shared_ptr<VersionedCredentials> updated = std::atomic_load(&creds_);

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -25,19 +25,6 @@
 namespace aws {
 namespace auth {
 
-struct DebugStats {
-  std::uint64_t update_before_load_;
-  std::uint64_t update_after_load_;
-  std::uint64_t version_mismatch_;
-  std::uint64_t success_;
-  std::uint64_t retried_;
-  std::uint64_t attempts_;
-  std::uint64_t used_lock_;
-
-  DebugStats() : update_before_load_(0), update_after_load_(0), version_mismatch_(0),
-                 success_(0), retried_(0), attempts_(0), used_lock_(0) {}
-};
-
 // Like basic static creds, but with an atomic set operation
 class MutableStaticCredentialsProvider
     : public Aws::Auth::AWSCredentialsProvider {
@@ -47,9 +34,6 @@ class MutableStaticCredentialsProvider
   void set_credentials(const std::string& akid, const std::string& sk, std::string token = "");
 
   Aws::Auth::AWSCredentials GetAWSCredentials() override;
-
-  DebugStats get_debug_stats();
-
 
  private:
   std::mutex update_mutex_;

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -18,8 +18,6 @@
 #include <atomic>
 #include <cstdint>
 #include <mutex>
-#include <array>
-#include <condition_variable>
 #include <memory>
 
 namespace aws {

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -25,6 +25,14 @@
 namespace aws {
 namespace auth {
 
+struct VersionedCredentials {
+  std::uint64_t version_;
+  Aws::Auth::AWSCredentials creds_;
+
+  VersionedCredentials() : version_(0), creds_("", "", "") {}
+  VersionedCredentials(std::uint64_t version, const std::string& akid, const std::string& sk, const std::string& token);
+};
+
 // Like basic static creds, but with an atomic set operation
 class MutableStaticCredentialsProvider
     : public Aws::Auth::AWSCredentialsProvider {
@@ -37,7 +45,8 @@ class MutableStaticCredentialsProvider
 
  private:
   std::mutex update_mutex_;
-  std::shared_ptr<Aws::Auth::AWSCredentials> creds_;
+  std::shared_ptr<VersionedCredentials> creds_;
+  std::atomic<std::uint64_t> version_;
 
 };
 

--- a/aws/auth/mutable_static_creds_provider.h
+++ b/aws/auth/mutable_static_creds_provider.h
@@ -19,6 +19,8 @@
 #include <cstdint>
 #include <mutex>
 #include <array>
+#include <condition_variable>
+#include <memory>
 
 namespace aws {
 namespace auth {
@@ -50,17 +52,8 @@ class MutableStaticCredentialsProvider
 
 
  private:
-  struct VersionedCredentials {
-    Aws::Auth::AWSCredentials creds_;
-    std::atomic<std::uint64_t> version_;
-    std::atomic<bool> updating_;
-    VersionedCredentials() : version_(0) {}
-  };
-  VersionedCredentials current_;
-
   std::mutex update_mutex_;
-
-  bool try_optimistic_read(Aws::Auth::AWSCredentials& destination);
+  std::shared_ptr<Aws::Auth::AWSCredentials> creds_;
 
 };
 

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -58,7 +58,7 @@ struct ResultsCounter {
 BOOST_AUTO_TEST_SUITE(MutableStaticCredsProviderTest)
 
 BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
-  const std::uint32_t kReaderThreadCount = 20;
+  const std::uint32_t kReaderThreadCount = 128;
   std::atomic<bool> test_running(true);
   std::array<ResultsCounter, kReaderThreadCount> results;
   std::array<aws::auth::DebugStats, kReaderThreadCount> debug_stats;

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
         std::string value = ss.str();
         provider.set_credentials(value, value, value);
         using namespace std::chrono_literals;
-//        std::this_thread::sleep_for(20ms);
+        std::this_thread::sleep_for(20ms);
       } while (now < end);
       LOG(info) << "Producer thread completed";
     });

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -82,6 +82,8 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
         ss << now_time << "-" << std::setfill('0') << std::setw(10) << counter;
         std::string value = ss.str();
         provider.set_credentials(value, value, value);
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(20ms);
       } while (now < end);
       LOG(info) << "Producer thread completed";
     });

--- a/aws/auth/test/mutable_static_creds_provider_test.cc
+++ b/aws/auth/test/mutable_static_creds_provider_test.cc
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(SinglePublisherMultipleReaders) {
         ++counter;
         std::stringstream ss;
         std::time_t now_time = system_clock::to_time_t(now);
-        ss << std::put_time(std::gmtime(&now_time), "%FT%T") << "-" << std::setfill('0') << std::setw(10) << counter;
+        ss << now_time << "-" << std::setfill('0') << std::setw(10) << counter;
         std::string value = ss.str();
         provider.set_credentials(value, value, value);
       } while (now < end);


### PR DESCRIPTION
Switched to use a shared_ptr for credential transfer, and thread_local for normal usage.  

This gets rid of a bug that could occur with the previous approach around destruction of the string objects, while preserving performance in most cases.