### PR TITLE
KinesisProducer is not correctly destroying callbackCompletionExecuto…

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -751,6 +751,7 @@ public class KinesisProducer implements IKinesisProducer {
     @Override
     public void destroy() {
         destroyed = true;
+        this.callbackCompletionExecutor.shutdownNow();
         child.destroy();
     }
 


### PR DESCRIPTION
…r #224

When destroying KinesisProducer instances, destroy method is not shutting down callbackCompletionExecutor. This makes Daemon child object to still be alive occupying 8MB of heap memory each one.

Creating and destroying lots of KinesisProducer instances will result in a Heap Out Of Memory exception.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
