### PR TITLE
Prepare for release 0.12.10 of the Amazon Kinesis Producer Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ This is a restatement of the [notice published](https://docs.aws.amazon.com/stre
 
 ## Release Notes
 
+### 0.12.10
+
+#### Java
+* Support for additional AWS regions.
+* Bug fix to avoid Heap Out of Memory Exception.
+  * [PR #225](https://github.com/awslabs/amazon-kinesis-producer/pull/225)
+  * [Issue #224](https://github.com/awslabs/amazon-kinesis-producer/issues/224)
+
+#### C++ Core
+* Support for additional AWS regions.
+* Update the CloudWatch upload login to timeout retries at 10 Minutes instead of 30 Minutes and backoff between retries.
+
 ### 0.12.9
 
 #### Java

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a restatement of the [notice published](https://docs.aws.amazon.com/stre
 
 #### C++ Core
 * Support for additional AWS regions.
-* Update the CloudWatch upload login to timeout retries at 10 Minutes instead of 30 Minutes and backoff between retries.
+* Update the CloudWatch upload logic to timeout retries at 10 Minutes instead of 30 Minutes and backoff between retries.
 
 ### 0.12.9
 

--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -363,7 +363,7 @@ class Configuration : private boost::noncopyable {
   //
   // The region is also used to sign requests.
   //
-  // Expected pattern: ^([a-z]+-[a-z]+-[0-9])?$
+  // Expected pattern: ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$
   const std::string& region() const noexcept {
     return region_;
   }
@@ -892,14 +892,14 @@ class Configuration : private boost::noncopyable {
   //
   // The region is also used to sign requests.
   //
-  // Expected pattern: ^([a-z]+-[a-z]+-[0-9])?$
+  // Expected pattern: ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$
   Configuration& region(std::string val) {
     static std::regex pattern(
-        "^([a-z]+-[a-z]+-[0-9])?$",
+        "^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$",
         std::regex::ECMAScript | std::regex::optimize);
     if (!std::regex_match(val, pattern)) {
       std::string err;
-      err += "region must match the pattern ^([a-z]+-[a-z]+-[0-9])?$, got ";
+      err += "region must match the pattern ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$, got ";
       err += val;
       throw std::runtime_error(err);
     }

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.12.7</version>
+            <version>0.12.10</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.9</version>
+    <version>0.12.10</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -696,7 +696,7 @@ public class KinesisProducerConfiguration {
      * <p>
      * The region is also used to sign requests.
      * 
-     * <p><b>Expected pattern</b>: ^([a-z]+-[a-z]+-[0-9])?$
+     * <p><b>Expected pattern</b>: ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$
      */
     public String getRegion() {
       return region;
@@ -1273,11 +1273,11 @@ public class KinesisProducerConfiguration {
      * <p>
      * The region is also used to sign requests.
      * 
-     * <p><b>Expected pattern</b>: ^([a-z]+-[a-z]+-[0-9])?$
+     * <p><b>Expected pattern</b>: ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$
      */
     public KinesisProducerConfiguration setRegion(String val) {
-        if (!Pattern.matches("^([a-z]+-[a-z]+-[0-9])?$", val)) {
-            throw new IllegalArgumentException("region must match the pattern ^([a-z]+-[a-z]+-[0-9])?$, got " + val);
+        if (!Pattern.matches("^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$", val)) {
+            throw new IllegalArgumentException("region must match the pattern ^([a-z]+-([a-z]+-)?[a-z]+-[0-9])?$, got " + val);
         }
         region = val;
         return this;


### PR DESCRIPTION
### 0.12.10
 #### Java
* Support for additional AWS regions.
* Bug fix to avoid Heap Out of Memory Exception.
  * [PR #225](https://github.com/awslabs/amazon-kinesis-producer/pull/225)
  * [Issue #224](https://github.com/awslabs/amazon-kinesis-producer/issues/224)
 #### C++ Core
* Support for additional AWS regions.
* Update the CloudWatch upload logic to timeout retries at 10 Minutes instead of 30 Minutes and backoff between retries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
