### PR TITLE
Prepare for release 0.12.11 of the Amazon Kinesis Producer Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ This is a restatement of the [notice published](https://docs.aws.amazon.com/stre
 
 ## Release Notes
 
+### 0.12.11
+
+#### Java
+
+* Bump up the version to 0.12.11.
+  * Fixes [Issue #231](https://github.com/awslabs/amazon-kinesis-producer/issues/231)
+
 ### 0.12.10
 
 #### Java

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.12.10</version>
+            <version>0.12.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.12.10</version>
+    <version>0.12.11</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>


### PR DESCRIPTION
### 0.12.11
 #### Java
* Bump up the version to 0.12.11. Maven release updated with working binaries.
  * Fixes [Issue #231](https://github.com/awslabs/amazon-kinesis-producer/issues/231)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
