### PR TITLE
Update aws sdk to be same as EMR 5.17.9

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -57,7 +57,7 @@
     </build>
 
     <properties>
-        <aws-sdk-core-version>1.11.312</aws-sdk-core-version>
+        <aws-sdk-core-version>1.11.336</aws-sdk-core-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The version of aws-sdk-core is different from those used in EMR.  emr-5.17.0 uses 1.11.336 