### PR TITLE
Update reference to non-existant property

### DIFF
--- a/java/amazon-kinesis-producer-sample/default_config.properties
+++ b/java/amazon-kinesis-producer-sample/default_config.properties
@@ -282,7 +282,7 @@ RecordTtl = 30000
 RequestTimeout = 6000
 
 # Verify the endpoint's certificate. Do not disable unless using
-# custom_endpoint for testing. Never disable this in production.
+# KinesisEndpoint for testing. Never disable this in production.
 #
 # Default: true
 VerifyCertificate = true


### PR DESCRIPTION
Updates comment in default configs to reference `KinesisEndpoint` instead of `custom_endpoint`, which no longer exists.

Relates to #120