### PR TITLE
Fix Typo in KinesisProducerConfiguration

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -634,7 +634,7 @@ public class KinesisProducerConfiguration {
     }
 
     /**
-     * Maximum amount of itme (milliseconds) a record may spend being buffered before it gets
+     * Maximum amount of time (milliseconds) a record may spend being buffered before it gets
      * sent. Records may be sent sooner than this depending on the other buffering limits.
      * 
      * <p>
@@ -1203,7 +1203,7 @@ public class KinesisProducerConfiguration {
     }
 
     /**
-     * Maximum amount of itme (milliseconds) a record may spend being buffered before it gets
+     * Maximum amount of time (milliseconds) a record may spend being buffered before it gets
      * sent. Records may be sent sooner than this depending on the other buffering limits.
      * 
      * <p>


### PR DESCRIPTION
*Description of changes:*
KinesisProducerConfiguration comment has a typo for the `getRecordMaxBufferedTime` and `setRecordMaxBufferedTime` method comments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
