### PR TITLE
Add endpoint for China Ningxia region

### DIFF
--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -38,7 +38,8 @@ struct EndpointConfiguration {
 
 const constexpr char* kVersion = "0.12.9N";
 const std::unordered_map< std::string, EndpointConfiguration > kRegionEndpointOverride = {
-  { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } }
+  { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } },
+  { "cn-northwest-1", { "kinesis.cn-northwest-1.amazonaws.com.cn", "monitoring.cn-northwest-1.amazonaws.com.cn" } }
 };
   const constexpr uint32_t kDefaultThreadPoolSize = 64;
 


### PR DESCRIPTION
*Issue #, if available: 259

*Description of changes:*

China Ningxia region (cn-northwest-1) was launched in Dec, 2017. The corresponding endpoint is not in current code. I added it by mocking the endpoint for Beijing region (cn-north-1). Due to lack of my test environment, I didn't test my code. Please help verify. Thank you.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
