### PR TITLE
Create a new process group on startup to allow safe shutdown when used with Ctrl-C console applications

### DIFF
--- a/aws/kinesis/main.cc
+++ b/aws/kinesis/main.cc
@@ -332,6 +332,14 @@ void set_core_limit() {
 #endif
 }
 
+void create_process_group() {
+#if !BOOST_OS_WINDOWS
+  if (setpgid(0, 0) != 0) {
+    LOG(error) << "Could not create a new process group";
+  }
+#endif
+}
+
 std::string get_ca_path() {
   std::string p = ".";
   if (!options.ca_path.empty()) {
@@ -371,6 +379,8 @@ int main(int argc, char* const* argv) {
     if (config->enable_core_dumps()) {
       set_core_limit();
     }
+
+    create_process_group()
 
     aws::utils::set_log_level(config->log_level());
 


### PR DESCRIPTION
Issue:
Pressing 'Ctrl-C' to issue a console application termination on UNIX systems will send a SIGINT signal to all processes in the parent's process group.
When using the KPL, this means that the child C++ binary process will receive a SIGINT when pressing Ctrl-C. It will attempt to flush its internal buffers, but the libraries at the other side of the pipe that the programmer interacts with directly cannot identify all the final records as pushed or not.
This makes the KPL currently incompatible with applications that have a lifecycle that may include Ctrl-C to terminate.

Changes:
This PR includes a call to setpgid() on the child process on UNIX systems. This will create a new process group for the child process, which means it will not receive a SIGINT when the parent receives a Ctrl-C; it can still be send a SIGINT specifically with its PID, but it will not panic and flush when the parent receives Ctrl-C.
This change seems to have no adverse side effects on all the testing we have performed, the KPL still closes successfully on application shutdown and no zombie KPL processes are left over; this change should only affect the behaviour of the KPL when used in an application where the user presses Ctrl-C, and should stop the data loss experienced then.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
