### PR TITLE
Add C++ compile flags to bootstrap.sh to compile aws-sdk-cpp with gcc 7

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,7 @@ if [ $1 == "clang" ] || [ $(uname) == 'Darwin' ]; then
 else
   export CC="gcc"
   export CXX="g++"
-  export CXXFLAGS="-I$INSTALL_DIR/include -O3"
+  export CXXFLAGS="-I$INSTALL_DIR/include -O3  -Wno-implicit-fallthrough -Wno-int-in-bool-context"
   export LDFLAGS="-L$INSTALL_DIR/lib "
   export LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH"
 fi


### PR DESCRIPTION
*Add C++ compile flags to bootstrap.sh to compile aws-sdk-cpp with gcc 7*

The dependency aws-sdk-cpp was failing to build with gcc7.4 because of two warnings that are new to gcc7.0. These warnings were  for implicit-fallthrough and int-in-bool-context. This change sets the CXXFlags in bootstrap.sh to build the aws sdk cpp dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
