### PR TITLE
Improve the Sample: Make it possible to run the producer and consumer without editing it.

### DIFF
--- a/java/amazon-kinesis-producer-sample/README.md
+++ b/java/amazon-kinesis-producer-sample/README.md
@@ -38,7 +38,7 @@ Build the sample application:
 mvn clean package
 ```
 
-Then run the producer to put some data into a stream called ``kpltest`` in ``us-west-2`` and for ``100 seconds``:
+Then run the producer to put some data into a stream called ``kpltest`` in ``us-west-2`` for ``100 seconds``:
 
 ```
 mvn exec:java -Dexec.mainClass="com.amazonaws.services.kinesis.producer.sample.SampleProducer" -Dexec.args="kpltest us-west-2 100"

--- a/java/amazon-kinesis-producer-sample/README.md
+++ b/java/amazon-kinesis-producer-sample/README.md
@@ -22,47 +22,30 @@ If running in EC2, the KPL will automatically retrieve credentials from any asso
 
 You can also pass credentials to the KPL programmatically during initialization.
 
-## Edit the Sample Application
+## Run the Sample Application
 
 The sample application is a Maven project. It takes dependencies on the KPL and KCL and contains both a producer and consumer.
 
 Refer to the documentation within the code files for more details about what it's actually doing.
 
-You will need to modify the stream name and region variables in the producer code to point the app at your own stream.
+The sample producer takes optional positional parameters for the stream name, region and duration of the test in seconds. The default stream name is ``test`` and default region is ``us-west-1``.
 
-In ```SampleProducer.java```, look for:
+The sample consumer takes optional positional parameters for the stream name and region.
 
-```
-/**
- * Change this to your stream name.
- */
-public static final String STREAM_NAME = "test";
-
-/**
- * Change this to the region you are using.
- * 
- * We do not use the SDK Regions enum because the KPL does not depend on the
- * SDK.
- */
-public static final String REGION = "us-west-1";
-```
-
-## Run the Sample
-
-After you've made the necessary changes, do a clean build:
+Build the sample application:
 
 ```
 mvn clean package
 ```
 
-Then run the producer to put some data into your stream:
+Then run the producer to put some data into a stream called ``kpltest`` in ``us-west-2`` and for ``100 seconds``:
 
 ```
-mvn exec:java -Dexec.mainClass="com.amazonaws.services.kinesis.producer.sample.SampleProducer"
+mvn exec:java -Dexec.mainClass="com.amazonaws.services.kinesis.producer.sample.SampleProducer" -Dexec.args="kpltest us-west-2 100"
 ```
 
-Finally run the consumer to retrieve that data:
+Finally run the consumer to retrieve the data from a stream called ``kpltest`` in ``us-west-2``:
 
 ```
-mvn exec:java -Dexec.mainClass="com.amazonaws.services.kinesis.producer.sample.SampleConsumer"
+mvn exec:java -Dexec.mainClass="com.amazonaws.services.kinesis.producer.sample.SampleConsumer" -Dexec.args="kpltest us-west-2"
 ```

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -18,21 +18,44 @@
         </plugins>
     </build>
     <name>KinesisProducerLibrary Sample Application</name>
+    <properties>
+         <aws-java-sdk.version>1.11.603</aws-java-sdk.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>1.10.0</version>
+            <version>1.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.12.11</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.13</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-cloudwatch</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/java/amazon-kinesis-producer-sample/src/com/amazonaws/services/kinesis/producer/sample/SampleConsumer.java
+++ b/java/amazon-kinesis-producer-sample/src/com/amazonaws/services/kinesis/producer/sample/SampleConsumer.java
@@ -193,14 +193,20 @@ public class SampleConsumer implements IRecordProcessorFactory {
         return this.new RecordProcessor();
     }
     
+    /** The main method.
+     *  @param args  The command line args for the Sample Producer. 
+     *  The main method takes 2 optional position parameters:
+     *  1. The stream name to use (test is default)
+     *  2. The region name to use (us-west-1 in default)
+     */
     public static void main(String[] args) {
         KinesisClientLibConfiguration config =
                 new KinesisClientLibConfiguration(
                         "KinesisProducerLibSampleConsumer",
-                        SampleProducer.STREAM_NAME,
+                        SampleProducer.getArgIfPresent(args, 0, SampleProducer.STREAM_NAME),
                         new DefaultAWSCredentialsProviderChain(),
                         "KinesisProducerLibSampleConsumer")
-                                .withRegionName(SampleProducer.REGION)
+                                .withRegionName(SampleProducer.getArgIfPresent(args, 1, SampleProducer.REGION))
                                 .withInitialPositionInStream(InitialPositionInStream.TRIM_HORIZON);
         
         final SampleConsumer consumer = new SampleConsumer();


### PR DESCRIPTION
Improve the Sample: 1. Fix dependency issues in pom.xml 2. In the producer stop using a threadpool to complete every future for every record sent 3. In the producer allow stream name region and run duration to be provided as optional positional parameters on the command line. 4.In the producer reduce aggregation period to allow records to be sent every 2 seconds to exercise the record sending code.  5. In the consumer allow stream name and region to be provided as command line parameters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
