### PR TITLE
Allow some additional buffer time for aggregating Kinesis Records into PutRecords calls

### DIFF
--- a/aws/utils/time_sensitive.h
+++ b/aws/utils/time_sensitive.h
@@ -63,6 +63,14 @@ class TimeSensitive : private boost::noncopyable {
     set_deadline(Clock::now() + ms);
   }
 
+  void extend_deadline_from_now(std::chrono::milliseconds ms) {
+    if (deadline().time_since_epoch().count() == 0) {
+      set_deadline_from_now(ms);
+    } else {
+      set_deadline(std::max(deadline_, Clock::now() + ms));
+    }
+  }
+
   void set_expiration_from_now(std::chrono::milliseconds ms) {
     expiration_ = Clock::now() + ms;
   }

--- a/aws/utils/time_sensitive.h
+++ b/aws/utils/time_sensitive.h
@@ -50,7 +50,7 @@ class TimeSensitive : private boost::noncopyable {
 
   void set_deadline(TimePoint tp) noexcept  {
     deadline_ = tp;
-    if (expiration_.time_since_epoch().count() > 0 && expiration_ < deadline_) {
+    if (!is_undefined(expiration_) && expiration_ < deadline_) {
       deadline_ = expiration_;
     }
   }
@@ -64,7 +64,7 @@ class TimeSensitive : private boost::noncopyable {
   }
 
   void extend_deadline_from_now(std::chrono::milliseconds ms) {
-    if (deadline().time_since_epoch().count() == 0) {
+    if (is_undefined(deadline())) {
       set_deadline_from_now(ms);
     } else {
       set_deadline(std::max(deadline_, Clock::now() + ms));
@@ -80,12 +80,12 @@ class TimeSensitive : private boost::noncopyable {
   }
 
   void inherit_deadline_and_expiration(const TimeSensitive& other) {
-    if (this->deadline().time_since_epoch().count() == 0 ||
+    if (is_undefined(this->deadline())  ||
         other.deadline() < this->deadline()) {
       this->set_deadline(other.deadline());
     }
 
-    if (this->expiration().time_since_epoch().count() == 0 ||
+    if (is_undefined(this->expiration()) ||
         other.expiration() < this->expiration()) {
       this->set_expiration(other.expiration());
     }
@@ -95,6 +95,11 @@ class TimeSensitive : private boost::noncopyable {
   TimePoint arrival_;
   TimePoint deadline_;
   TimePoint expiration_;
+
+  static bool is_undefined(const TimePoint& tp) {
+    return tp.time_since_epoch().count() == 0;  
+  }
+
 };
 
 } //namespace utils


### PR DESCRIPTION
When aggregation is enabled and all the buffer time is consumed for aggregating User records into Kinesis records, allow some additional buffer time for aggregating Kinesis Records into PutRecords calls.

*Description of changes:*
  Before this fix, when aggregation is enabled and all the available buffer time is spent buffering user records into Kinesis records, PutRecords calls were made with very few records per batch (often just a single one). This effect was stronger when the record buffer time was low and the destination stream was larger (> 200 shards). This lead to higher load on the producers and potential instability while writing to larger streams.

  This change provides some additional buffer time, only when aggregation is enabled, to allow more Kinesis records to be batched into PutRecords calls. We do not eat into the time available for aggregating User records into Kinesis records, as that could increase the number of Kinesis records generated and thus raise customer costs.
  Instead, only if necessary, we spend an additional buffer time to aggregate more Kinesis records into PutRecords calls. The additional buffer time is calculated as the lower of 20 % of record buffer time or 50 ms. So at a maximum penalty of 50 ms of additional delay, this change brings down the number of PutRecords calls per producer by a factor of 40 to 50.
  50 ms was chosen as the maximum additional delay since a producer should be able to sustain 20 TPS without problem.

* Testing *
* Tested on long running tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
