### PR TITLE
Forward log level to daemon

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -435,6 +435,12 @@ public class Daemon {
                 inPipe.getAbsolutePath(), "-c", protobufToHex(config.toProtobufMessage()), "-k",
                 protobufToHex(makeSetCredentialsMessage(config.getCredentialsProvider(), false)), "-t"));
 
+        if ("warning".equals(config.getLogLevel())) {
+            args.addAll(Arrays.asList("-l", "warn"));
+        } else {
+            args.addAll(Arrays.asList("-l", config.getLogLevel()));
+        }
+
         AWSCredentialsProvider metricsCreds = config.getMetricsCredentialsProvider();
         if (metricsCreds == null) {
             metricsCreds = config.getCredentialsProvider();

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
@@ -175,6 +175,9 @@ public class KinesisProducerTest {
     
     @Test
     public void multipleInstances() throws Exception {
+        final AWSCredentialsProvider credsProvider = new StaticCredentialsProvider(
+                new BasicAWSCredentials("AKIAAAAAAAAAAAAAAAAA", StringUtils.repeat("a", 40)));
+
         int N = 8;
         final KinesisProducer[] kps = new KinesisProducer[N];
         ExecutorService exec = Executors.newFixedThreadPool(N);
@@ -184,7 +187,7 @@ public class KinesisProducerTest {
                 @Override
                 public void run() {
                     try {
-                        kps[n] = getProducer(null, null);
+                        kps[n] = getProducer(credsProvider, credsProvider);
                     } catch (Exception e) {
                         log.error("Error starting KPL", e);
                     }


### PR DESCRIPTION
Issue: https://github.com/awslabs/amazon-kinesis-producer/issues/137

Changes: 
Quick change to pass on the log level from the main app to the daemon process. Note that the daemon expects `warn` instead of `warning`. I also made a small change to the `multipleInstances` test in order for it to pass on my machine. For reference I am on `OSX 10.14.6` with `OpenJDK Runtime Environment Corretto-8.232.09.2 (build 1.8.0_232-b09)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
