### PR TITLE
Travis-CI Integration for Mac OSX Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+os: osx
+osx_image: xcode9.3
+language: java
+compiler: clang
+addons:
+  homebrew:
+    packages:
+    - maven
+    - ant
+    update: true
+jobs:
+  include:
+    - stage: pre-build
+      name: "Pre-Build"
+      before_install:
+        - cd java
+      script:
+        - echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
+        - export CC=clang
+        - export CXX=clang++
+        - LDFLAGS="-L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
+        - cd ..
+    - stage: build
+      name: "Build C++"
+      before_script:
+       - cd java/amazon-kinesis-producer
+       - KPL_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+       - echo "Found KPL version $KPL_VERSION in current directory $PWD ... "
+       - echo "Starting Packaging of KPL.$KPL_VERSION"
+       - cd ../..
+      script: ./bootstrap.sh
+    - stage: upload
+      name: "Upload to S3"
+      script:
+       - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/osx
+       - zip kinesis-producer.zip kinesis_producer
+       - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION/osx/kinesis-producer.zip
+       - cd ../../../../../../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     packages:
     - maven
     - ant
+    - awscli
     update: true
 jobs:
   include:
@@ -21,7 +22,7 @@ jobs:
         - LDFLAGS="-L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
         - cd ..
     - stage: build
-      name: "Build C++"
+      name: "Build C++/Java and Upload to S3"
       before_script:
        - cd java/amazon-kinesis-producer
        - KPL_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -29,9 +30,7 @@ jobs:
        - echo "Starting Packaging of KPL.$KPL_VERSION"
        - cd ../..
       script: ./bootstrap.sh
-    - stage: upload
-      name: "Upload to S3"
-      script:
+      after_success:
        - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/osx
        - zip kinesis-producer.zip kinesis_producer
        - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION/osx/kinesis-producer.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,6 @@ addons:
     update: true
 jobs:
   include:
-    - stage: pre-build
-      name: "Pre-Build"
-      before_install:
-        - cd java
-      script:
-        - echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
-        - export CC=clang
-        - export CXX=clang++
-        - LDFLAGS="-L$(brew --prefix)/opt/llvm/lib -Wl,-rpath,$(brew --prefix)/opt/llvm/lib"
-        - cd ..
     - stage: build
       name: "Build C++/Java and Upload to S3"
       before_script:
@@ -29,9 +19,12 @@ jobs:
        - echo "Found KPL version $KPL_VERSION in current directory $PWD ... "
        - echo "Starting Packaging of KPL.$KPL_VERSION"
        - cd ../..
-      script: ./bootstrap.sh
+      script:
+       - ./bootstrap.sh
+       - if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_EVENT_TYPE" != pull_request ]]; then cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME; fi
+       - if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_EVENT_TYPE" != pull_request ]]; then zip kinesis-producer.zip kinesis_producer; fi
+       - if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_EVENT_TYPE" != pull_request ]]; then aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION/$TRAVIS_OS_NAME/kinesis-producer.zip; fi
       after_success:
-       - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/osx
-       - zip kinesis-producer.zip kinesis_producer
-       - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION/osx/kinesis-producer.zip
-       - cd ../../../../../../..
+        - sleep 10
+      after_failure:
+        - sleep 10

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -119,8 +119,8 @@ if [ ! -d "openssl-1.0.1m" ]; then
     ./config $OPTS --prefix=$INSTALL_DIR
   fi
 
-  make # don't use -j, doesn't work half the time
-  make install
+  make > /dev/null # don't use -j, doesn't work half the time
+  make install > /dev/null
 
   cd ..
 fi
@@ -164,8 +164,8 @@ if [ ! -d "zlib-1.2.8" ]; then
 
   cd zlib-1.2.8
   ./configure --static --prefix="$INSTALL_DIR"
-  make -j
-  make install
+  make -j > /dev/null
+  make install > /dev/null
 
   cd ..
 fi
@@ -178,8 +178,8 @@ if [ ! -d "protobuf-2.6.1" ]; then
 
   cd protobuf-2.6.1
   conf --enable-shared=no
-  make -j
-  make install
+  make -j > /dev/null
+  make install > /dev/null
 
   cd ..
 fi
@@ -204,8 +204,8 @@ if [ ! -d "curl-7.47.0" ]; then
     #
     sed -Ei .bak 's/#define HAVE_CLOCK_GETTIME_MONOTONIC 1//' lib/curl_config.h
   fi
-  make -j
-  make install
+  make -j > /dev/null
+  make install > /dev/null
 
   cd ..
 fi
@@ -233,9 +233,9 @@ if [ ! -d "aws-sdk-cpp" ]; then
     -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
     -DCMAKE_FIND_FRAMEWORK=LAST \
     -DENABLE_TESTING="OFF" \
-    ../aws-sdk-cpp
-  make -j 4
-  make install
+    ../aws-sdk-cpp > /dev/null
+  make -j 4 > /dev/null
+  make install > /dev/null
 
   cd ..
 
@@ -260,4 +260,3 @@ popd
 
 set +e
 set +x
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Travis-CI integration for building Mac OSX binaries and upload to s3.

* Silence added due to log size limitations on Travis-CI. When logs exceed 4MB, Travis forcibly fails the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
