### PR TITLE
Upgrade dependency flagged by Dependabot alerts

### DIFF
--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -101,12 +101,12 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.2.Final</version>
+            <version>6.0.18.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-annotation-processor</artifactId>
-            <version>6.0.2.Final</version>
+            <version>6.0.18.Final</version>
         </dependency>
     </dependencies>
 </project>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
*Issue*

https://github.com/advisories/GHSA-mvr2-9pj6-7w5j
https://github.com/advisories/GHSA-m8p2-495h-ccmh

*Description of changes:*
upgrade org.hibernate.validator:hibernate-validator 6.0.2.Final -> 6.0.18.Final
upgrade com.google.guava:guava 18.0 -> 24.1.1-jre

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
