### PR TITLE
upgrade guava, boost C++ link

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,8 +13,8 @@ silence() {
 }
 
 LIB_OPENSSL="https://ftp.openssl.org/source/old/1.0.1/openssl-1.0.1m.tar.gz"
-LIB_BOOST="https://astuteinternet.dl.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.gz"
-LIB_ZLIB="https://zlib.net/fossils/zlib-1.2.8.tar.gz" 
+LIB_BOOST="http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz"
+LIB_ZLIB="https://zlib.net/fossils/zlib-1.2.8.tar.gz"
 LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protobuf-all-3.11.4.tar.gz"
 LIB_CURL="https://curl.haxx.se/download/curl-7.47.0.tar.gz"
 

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.1.1-jre</version>
+            <version>26.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
*Issue #, if available:*
- Upgrade Guava to 26.0-jre
- Update BOOST C++ Libraries link as cert expired on the older link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
