### PR TITLE
Include the FileAgeManager into the producer lifecycle

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/FileAgeManager.java
@@ -30,12 +30,6 @@ class FileAgeManager implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(FileAgeManager.class);
 
-    private static final FileAgeManager instance = new FileAgeManager();
-
-    static synchronized FileAgeManager instance() {
-        return instance;
-    }
-
     private final ScheduledExecutorService executorService;
 
     private final Set<File> watchedFiles;
@@ -70,5 +64,10 @@ class FileAgeManager implements Runnable {
                 }
             }
         }
+    }
+
+    public synchronized void close() throws InterruptedException {
+        this.executorService.shutdown();
+        this.executorService.awaitTermination(10, TimeUnit.MINUTES);
     }
 }


### PR DESCRIPTION
https://github.com/awslabs/amazon-kinesis-producer/issues/308

The FileAgeManager will be created and destroyed with the KinesisProducer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
