### PR TITLE
Adding kpl config to allow ca cert path to be overriden.

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -241,15 +241,20 @@ public class KinesisProducer implements IKinesisProducer {
      */
     public KinesisProducer(KinesisProducerConfiguration config) {
         this.config = config;
-        
+        String caPath = config.getCaCertPath();
         String caDirectory = extractBinaries();
-        
+        // Override the CA cert path if provided by the user config
+        if(!StringUtils.isEmpty(caPath)) {
+            log.info("Overrding the ca cert path to use as provided in the kpl config to be " + caPath);
+            caDirectory = caPath;
+        }
+
         env = new ImmutableMap.Builder<String, String>()
                 .put("LD_LIBRARY_PATH", pathToLibDir)
                 .put("DYLD_LIBRARY_PATH", pathToLibDir)
                 .put("CA_DIR", caDirectory)
                 .build();
-        
+
         child = new Daemon(pathToExecutable, new MessageHandler(), pathToTmpDir, config, env);
     }
     

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -218,6 +218,22 @@ public class KinesisProducerConfiguration {
         
         return config;
     }
+
+    /**
+     * Use a provided cacert path to use which should be a full path to the cert location. When provided KPL will use
+     * this path to find certs and if empty, KPL will use the internal default certs.
+     */
+    public KinesisProducerConfiguration setCaCertPath(String val) {
+        caCertPath = val;
+        return this;
+    }
+
+    /**
+     * Return the provided cacert path
+     */
+    public String getCaCertPath() {
+        return caCertPath;
+    }
     
     protected Configuration.Builder additionalConfigsToProtobuf(Configuration.Builder builder) {
         return builder.addAllAdditionalMetricDims(additionalDims);
@@ -275,6 +291,7 @@ public class KinesisProducerConfiguration {
     private boolean verifyCertificate = true;
     private ThreadingModel threadingModel = ThreadingModel.PER_REQUEST;
     private int threadPoolSize = 0;
+    private String caCertPath = "";
 
     /**
      * Enable aggregation. With aggregation, multiple user records are packed into a single


### PR DESCRIPTION
*Issue # https://sim.amazon.com/issues/Streamy-4141

*Description of changes:* This change allows user to override the ca cert path in KPL to a their own path hence allowing to provide custom paths for specific use cases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
