### PR TITLE
KPL goes into a continous retry storm if the stream is deleted and re-created

### DIFF
--- a/aws/kinesis/core/retrier.cc
+++ b/aws/kinesis/core/retrier.cc
@@ -199,7 +199,6 @@ bool Retrier::succeed_if_correct_shard(const std::shared_ptr<UserRecord>& ur,
       *ur->predicted_shard() != actual_shard) {
     //We should call invalidate only if:
     // 1. If we are told to invalidate on incorrect shard.
-    // 2. The actual destination shard is newer than the predicted shard.
     if (should_invalidate_on_incorrect_shard) {
       LOG(warning) << "Record went to shard " << shard_id << " instead of the "
                    << "predicted shard " << *ur->predicted_shard() << "; this "

--- a/aws/kinesis/core/retrier.cc
+++ b/aws/kinesis/core/retrier.cc
@@ -200,7 +200,7 @@ bool Retrier::succeed_if_correct_shard(const std::shared_ptr<UserRecord>& ur,
     //We should call invalidate only if:
     // 1. If we are told to invalidate on incorrect shard.
     // 2. The actual destination shard is newer than the predicted shard.
-    if (should_invalidate_on_incorrect_shard && actual_shard > *ur->predicted_shard()) {
+    if (should_invalidate_on_incorrect_shard) {
       LOG(warning) << "Record went to shard " << shard_id << " instead of the "
                    << "predicted shard " << *ur->predicted_shard() << "; this "
                    << "usually means the sharp map has changed.";    


### PR DESCRIPTION
*Issue #, if available:*
The Issue is that when a customer deletes a stream after scaling the stream for multiple times and then creates the stream with same number of shards. The KPL producer is going into continuous retry storm with error "Wrong Shard ErrorMessages: [Record did not end up in expected shard ... "  but no "Record went to shard x instead of shard y.." log message. 
This means, KPL has never tried to update the shard map, which is done at line 208 in retrier.cc file.

This is a bug where KPL assumes that a record can go into a different shard only when the same stream has scaled and then updates the shard Map. Hence removing this check ("The actual destination shard is newer than the predicted shard.")

*Description of changes:*
Hence removing the extra check "The actual destination shard is newer than the predicted shard." to update shard map. Hence the shard map will be updated every time there is invalidate on incorrect shard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.