### PR TITLE
Add support for building multiple architectures, specifically arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       dist: trusty
       before_install:
         - echo "################################################################################"
-        - echo "Installing Dependencies for Linux"
+        - echo "Installing Dependencies for Linux/x86_64"
         - echo "################################################################################"
         - sudo apt-get update
         - sudo apt-get install python3
@@ -21,11 +21,11 @@ matrix:
           aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
         - cat <<'EOF' >> ~/.aws/credentials
         - echo "################################################################################"
-        - echo "SUCCESS Installed Dependencies for Linux"
+        - echo "SUCCESS Installed Dependencies for Linux/x86_64"
         - echo "################################################################################"
       script:
         - echo "################################################################################"
-        - echo "Starting build phase for Linux"
+        - echo "Starting build phase for Linux/x86_64"
         - echo "################################################################################"
         - $(aws ecr get-login --no-include-email --region us-west-2)
         - echo "Getting Docker image for AL2012 build of KPL..."
@@ -34,13 +34,57 @@ matrix:
         - df -h
         - echo "Building KPL in current directory in the Container..."
         - docker run --memory 9g -v $(pwd):/kpl -it 056543101242.dkr.ecr.us-west-2.amazonaws.com/kinesis-producer-library-builder:latest /bin/bash -c "export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID && cd /kpl && ls && ./bootstrap.sh"
-        - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME
+        - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME-`uname -m`
         - ls
         - sudo zip kinesis-producer.zip kinesis_producer
         - echo "Uploading build artifacts for KPL built on Linux..."
-        - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/$TRAVIS_OS_NAME/kinesis-producer.zip
+        - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/$TRAVIS_OS_NAME-`uname -m`/kinesis-producer.zip
         - echo "################################################################################"
-        - echo "SUCCESS Build phase for Linux, complete. Check for any errors reported"
+        - echo "SUCCESS Build phase for Linux/x86_64, complete. Check for any errors reported"
+        - echo "################################################################################"
+    - name: "Build C++/Java and Upload to S3 on AL2/Arm64"
+      os: linux
+      arch: arm64-graviton2
+      virt: vm
+      services: docker
+      dist: focal
+      before_install:
+        - echo "################################################################################"
+        - echo "Installing Dependencies for Linux/arm64"
+        - echo "################################################################################"
+        - sudo apt-get update
+        - sudo apt-get install python3
+        - sudo apt-get -y install python3-pip
+        - pip3 --version
+        - pip3 install --user awscli
+        - mkdir -p ~/.aws
+        - |
+          cat > ~/.aws/credentials << EOF
+          [default]
+          aws_access_key_id = $AWS_ACCESS_KEY_ID
+          aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+        - cat <<'EOF' >> ~/.aws/credentials
+        - echo "################################################################################"
+        - echo "SUCCESS Installed Dependencies for Linux/arm64"
+        - echo "################################################################################"
+      script:
+        - echo "################################################################################"
+        - echo "Starting build phase for Linux/arm64"
+        - echo "################################################################################"
+        - $(aws ecr get-login --no-include-email --region us-west-2)
+        - echo "Getting Docker image for AL2/Arm64 build of KPL..."
+        - docker pull amazonlinux:2
+        - ls
+        - df -h
+        - echo "Building KPL in current directory in the Container..."
+        - docker run --memory 9g -v $(pwd):/kpl -it amazonlinux:2 /bin/bash -c "yum install -y -q cmake3 gcc gcc-c++ make file tar gzip which perl git libuuid libuuid-devel maven zlib zlib-devel zlib-static && cd /kpl && ls && ./bootstrap.sh"
+        - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME-`uname -m`
+        - ls
+        - sudo zip kinesis-producer.zip kinesis_producer
+        - echo "Uploading build artifacts for KPL built on Linux Arm64..."
+        - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/$TRAVIS_OS_NAME-`uname -m`/kinesis-producer.zip
+        - echo "################################################################################"
+        - echo "SUCCESS Build phase for Linux/arm64, complete. Check for any errors reported"
         - echo "################################################################################"
     - name: "Build C++/Java and Upload to S3 on OSX"
       os: osx
@@ -55,20 +99,33 @@ matrix:
       script:
        - DIR=$(pwd)
        - ./bootstrap.sh
-       - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME
+       - cd java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$TRAVIS_OS_NAME-`uname -m`
        - zip kinesis-producer.zip kinesis_producer
-       - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/$TRAVIS_OS_NAME/kinesis-producer.zip
+       - aws s3 cp kinesis-producer.zip s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/$TRAVIS_OS_NAME-`uname -m`/kinesis-producer.zip
        - echo "################################################################################"
-       - echo "Finished building KPL on OSX...Starting Bundling of Linux with OSX binaries"
+       - echo "Finished building KPL on OSX...Starting Bundling of Linux/x86_64 with OSX binaries"
        - echo "################################################################################"
-       - test -e $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/osx/kinesis_producer
-       - aws s3 cp s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/linux/kinesis-producer.zip linux-binaries.zip
-       - mkdir -p java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux/
-       - unzip linux-binaries.zip -d $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux/
-       - cd $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux/
+       - test -e $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/osx-`uname -m`/kinesis_producer
+       - aws s3 cp s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/linux-x86_64/kinesis-producer.zip linux-x86_64-binaries.zip
+       - mkdir -p java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-x86_64/
+       - unzip linux-x86_64-binaries.zip -d $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-x86_64/
+       - cd $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-x86_64/
        - pwd
        - ls
-       - test -e $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux/kinesis_producer
+       - test -e $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-x86_64/kinesis_producer
+       - cd $DIR
+       - pwd
+       - ls
+       - echo "################################################################################"
+       - echo "Starting Bundling of Linux/arm64 with OSX binaries"
+       - echo "################################################################################"
+       - aws s3 cp s3://kpl-build-kinesis-internal/$KPL_VERSION-$HASH/linux-aarch64/kinesis-producer.zip linux-aarch64-binaries.zip
+       - mkdir -p java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-aarch64/
+       - unzip linux-aarch64-binaries.zip -d $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-aarch64/
+       - cd $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-aarch64/
+       - pwd
+       - ls
+       - test -e $DIR/java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/linux-aarch64/kinesis_producer
        - cd $DIR
        - pwd
        - ls

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(amazon_kinesis_producer)
+include(CheckCCompilerFlag)
+
 
 set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_SOURCE_DIR}/third_party/lib")
 
@@ -158,6 +160,10 @@ if(LINUX)
 
     add_library(libUUID STATIC IMPORTED)
 
+    check_c_compiler_flag(-moutline-atomics HAS_MOUTLINE_ATOMICS)
+    if (HAS_MOUTLINE_ATOMICS)
+        list(APPEND AWS_C_FLAGS -moutline-atomics)
+    endif()
 endif(LINUX)
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,7 +42,7 @@ function find_release_type() {
 	echo "unknown"
 }
 
-
+CMAKE=$(which cmake3 &> /dev/null && echo "cmake3 " || echo "cmake")
 RELEASE_TYPE=$(find_release_type)
 
 [[ $RELEASE_TYPE == "unknown" ]] && {
@@ -231,7 +231,7 @@ if [ ! -d "aws-sdk-cpp" ]; then
 
   cd aws-sdk-cpp-build
 
-  silence cmake \
+  silence $CMAKE \
     -DBUILD_ONLY="kinesis;monitoring" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DSTATIC_LINKING=1 \
@@ -253,7 +253,7 @@ fi
 cd ..
 
 #Build the native kinesis producer
-cmake -DCMAKE_PREFIX_PATH="$INSTALL_DIR" .
+$CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" .
 make -j8
 
 #copy native producer to a location that the java producer can package it

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ silence() {
 }
 
 LIB_OPENSSL="https://ftp.openssl.org/source/old/1.0.1/openssl-1.0.1m.tar.gz"
-LIB_BOOST="http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz"
+LIB_BOOST="http://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz"
 LIB_ZLIB="https://zlib.net/fossils/zlib-1.2.8.tar.gz"
 LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protobuf-all-3.11.4.tar.gz"
 LIB_CURL="https://curl.haxx.se/download/curl-7.47.0.tar.gz"
@@ -135,12 +135,12 @@ if [ ! -d "openssl-1.0.1m" ]; then
 fi
 
 # Boost C++ Libraries
-if [ ! -d "boost_1_58_0" ]; then
+if [ ! -d "boost_1_61_0" ]; then
   _curl "$LIB_BOOST" > boost.tgz
   tar xf boost.tgz
   rm boost.tgz
 
-  cd boost_1_58_0
+  cd boost_1_61_0
 
   LIBS="atomic,chrono,log,system,test,random,regex,thread,filesystem"
   OPTS="-j 8 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,10 +29,10 @@ mkdir -p $INSTALL_DIR
 # of the native binary
 function find_release_type() {
   if [[ $OSTYPE == "linux-gnu" ]]; then
-		echo "linux"
+		echo "linux-$(uname -m)"
 		return
 	elif [[ $OSTYPE == darwin* ]]; then
-		echo "osx"
+		echo "osx-$(uname -m)"
 		return
 	elif [[ $OSTYPE == "msys" ]]; then
 		echo "windows"

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -976,9 +976,9 @@ public class KinesisProducer implements IKinesisProducer {
             if (SystemUtils.IS_OS_WINDOWS) {
                 os = "windows";
             } else if (SystemUtils.IS_OS_LINUX) {
-                os = "linux";
+                os = "linux-" + SystemUtils.OS_ARCH;
             } else if (SystemUtils.IS_OS_MAC_OSX) {
-                os = "osx";
+                os = "osx-" + SystemUtils.OS_ARCH;
             } else {
                 throw new RuntimeException("Your operation system is not supported (" +
                         os + "), the KPL only supports Linux, OSX and Windows");


### PR DESCRIPTION
*Issue #, if available:* #258

*Description of changes:*
Add support for building and using binaries for multiple architectures, specifically arm64 to support AWS Graviton based instances, but this should also enable Apple M1 based OS X systems as well. Bumped Boost slightly to a version that includes Arm support and added the architecture to the path for kinesis_producer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
