### PR TITLE
Fixing KPL not emmiting Kinesis PutRecords call context metrics.

### DIFF
--- a/aws/kinesis/core/retrier.cc
+++ b/aws/kinesis/core/retrier.cc
@@ -47,6 +47,7 @@ Retrier::handle_put_records_result(std::shared_ptr<PutRecordsContext> prc) {
   auto start = prc->get_start();
   auto end = prc->get_end();
 
+  emit_metrics(prc); // Emit PutRecords call specific metrics like client side latencies, records per call etc.
 
   if (!outcome.IsSuccess()) {
     auto e = outcome.GetError();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixing KPL not emmiting Kinesis PutRecords call context metrics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
