### PR TITLE
Ignore all exceptions when terminating daemon.

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -525,7 +525,9 @@ public class Daemon {
             }
             try {
                 executor.awaitTermination(1, TimeUnit.SECONDS);
-            } catch (InterruptedException e) { }
+            } catch (Exception e) {
+                log.warn("Wait termination of executor failed", e);
+            }
             executor.shutdownNow();
             if (handler != null) {
                 if (retryable) {


### PR DESCRIPTION
***Issue*** https://github.com/awslabs/amazon-kinesis-producer/issues/354

***Description of changes:***
Ignore all exceptions (checked & unchecked) that occurs during `executor.awaitTermination`.  This ensures the executor is terminated and will be restarted.  Also logged a warn so exception messages is not lost.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
