### PR TITLE
Updating image to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
     - name: "Build C++/Java and Upload to S3 on AL2012"
       os: linux
       services: docker
-      dist: trusty
+      dist: xenial
       before_install:
         - echo "################################################################################"
         - echo "Installing Dependencies for Linux/x86_64"


### PR DESCRIPTION
Looks like the build has been failing for some time, this seems to be because Travis's `trusty` image is outdated and doesn't have some of keys to pull a few packages. Switching over to the `xenial` image fixes this, and we're still building on the same `AL2` platform.
```
W: G	: http://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 78BD65473CB3BD13
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
