### PR TITLE
Support Glue Schema Registry JSON data format

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
**Description of changes:**

Support the JSON data format with Glue Schema Registry. Version 1.1.0 of `schema-registry-serde` introduces JSON data format support.

**Testing**

Changes can be built successfully and JSON data format is tested with Kinesis Sample Producer. Verified that there are no regressions with Avro.
