### PR TITLE
Bump up Glue Schema Registry to 1.1.1

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support the JSON data format with Glue Schema Registry. Version 1.1.0 of schema-registry-serde introduces JSON data format support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
