### PR TITLE
Use shardFilter during listShards to only get active shards and reduce latency in shard scaling events

### DIFF
--- a/aws/kinesis/core/shard_map.cc
+++ b/aws/kinesis/core/shard_map.cc
@@ -97,7 +97,10 @@ void ShardMap::update() {
 
 void ShardMap::list_shards(const Aws::String& next_token) {
   Aws::Kinesis::Model::ListShardsRequest req;
+  Aws::Kinesis::Model::ShardFilter filter;
+  filter.SetType(Aws::Kinesis::Model::ShardFilterType::AT_LATEST);
   req.SetMaxResults(1000);
+  req.SetShardFilter(filter);
 
   if (!next_token.empty()) {
     req.SetNextToken(next_token);
@@ -192,3 +195,4 @@ void ShardMap::sort_all_open_shards() {
 } //namespace core
 } //namespace kinesis
 } //namespace aws
+

--- a/aws/metrics/test/metrics_manager_test.cc
+++ b/aws/metrics/test/metrics_manager_test.cc
@@ -18,6 +18,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <aws/core/AmazonWebServiceResult.h>
 #include <aws/core/NoResult.h>
 #include <aws/metrics/metrics_manager.h>
 #include <aws/monitoring/model/PutMetricDataRequest.h>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -224,7 +224,7 @@ fi
 if [ ! -d "aws-sdk-cpp" ]; then
   git clone https://github.com/awslabs/aws-sdk-cpp.git aws-sdk-cpp
   pushd aws-sdk-cpp
-  git checkout 1.7.180
+  git checkout 1.8.30
   popd
 
   rm -rf aws-sdk-cpp-build
@@ -271,3 +271,4 @@ popd
 
 set +e
 set +x
+


### PR DESCRIPTION

*Issue #, if available:*
Current implementation pulls all shards with listShardsRequest without filtering non active shards and in shard scaling event it contributes to latency increase. Use shardFilter to get only active shards.
*Description of changes:*
Bump up AWS SDK version. 
Use shardFilter with listShardsRequest.
Include header to avoid compilation error. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
