### PR TITLE
List shards with filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.13")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The KPL is written in C++ and runs as a child process to the main user process. 
 The Java package should run without the need to install any additional native libraries on the following operating systems:
 
 + Linux distributions with glibc 2.9 or later
-+ Apple OS X 10.9 and later
++ Apple OS X 10.13 and later
 
 Note the release is 64-bit only.
 

--- a/aws/kinesis/core/shard_map.cc
+++ b/aws/kinesis/core/shard_map.cc
@@ -103,6 +103,9 @@ void ShardMap::list_shards(const Aws::String& next_token) {
     req.SetNextToken(next_token);
   } else {
     req.SetStreamName(stream_);
+    Aws::Kinesis::Model::ShardFilter shardFilter;
+    shardFilter.SetType(Aws::Kinesis::Model::ShardFilterType::AT_LATEST);
+    req.SetShardFilter(shardFilter);
   }
 
   kinesis_client_->ListShardsAsync(

--- a/aws/metrics/test/metrics_manager_test.cc
+++ b/aws/metrics/test/metrics_manager_test.cc
@@ -18,6 +18,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <aws/core/AmazonWebServiceResult.h>
 #include <aws/core/NoResult.h>
 #include <aws/metrics/metrics_manager.h>
 #include <aws/monitoring/model/PutMetricDataRequest.h>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,7 +53,7 @@ RELEASE_TYPE=$(find_release_type)
 
 if [ $1 == "clang" ] || [ $(uname) == 'Darwin' ]; then
   export MACOSX_DEPLOYMENT_TARGET='10.13'
-  export MACOSX_MIN_COMPILER_OPT="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+  export MACOSX_MIN_COMPILER_OPT="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -framework CoreFoundation -framework SystemConfiguration -framework Security"
   export CC=$(which clang)
   export CXX=$(which clang++)
   export CXXFLAGS="-I$INSTALL_DIR/include -O3 -stdlib=libc++ ${MACOSX_MIN_COMPILER_OPT} "

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,7 +52,7 @@ RELEASE_TYPE=$(find_release_type)
 
 
 if [ $1 == "clang" ] || [ $(uname) == 'Darwin' ]; then
-  export MACOSX_DEPLOYMENT_TARGET='10.9'
+  export MACOSX_DEPLOYMENT_TARGET='10.13'
   export MACOSX_MIN_COMPILER_OPT="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
   export CC=$(which clang)
   export CXX=$(which clang++)
@@ -224,7 +224,7 @@ fi
 if [ ! -d "aws-sdk-cpp" ]; then
   git clone https://github.com/awslabs/aws-sdk-cpp.git aws-sdk-cpp
   pushd aws-sdk-cpp
-  git checkout 1.7.180
+  git checkout 1.8.30
   popd
 
   rm -rf aws-sdk-cpp-build


### PR DESCRIPTION
Issue #, if available:
Current implementation pulls all shards with listShardsRequest without filtering non active shards and in shard scaling event it contributes to latency increase. Use shardFilter to get only active shards.
Related: #372
Description of changes:
Bump up AWS SDK version.
Use shardFilter with listShardsRequest.
Include header to avoid compilation error.
Testing:
This change is not unit testable due to the nature of the change is to change server side behavior hence I had to go down manual integration test route.
Test case: Manually changed req.SetMaxResults(1000); to req.SetMaxResults(10); and tested against a stream of previously 100 shards, but re-sharded to 128 shards in my test account, and was able to get 12 paginated results with total of 128 open shards

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.