### PR TITLE
Emit usage metrics for glue schema registry

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -53,6 +53,44 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Required for generating maven version as a Java class for runtime access -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-version-class</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dist</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/target/generated-sources/java-templates/</directory>
+                                    <filtering>false</filtering>
+                                    <excludes>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -94,7 +132,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.3</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/amazon-kinesis-producer/src/main/java-templates/KinesisProducerLibraryPackage.java
+++ b/java/amazon-kinesis-producer/src/main/java-templates/KinesisProducerLibraryPackage.java
@@ -1,0 +1,5 @@
+package com.amazonaws.services.kinesis.producer;
+
+public final class KinesisProducerLibraryPackage {
+    public static final String VERSION = "${project.version}";
+}

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
-    private static final String USER_AGENT_APP_NAME = "kpl";
+    private static final String USER_AGENT_APP_NAME = "kpl" + "-" + KinesisProducerLibraryPackage.VERSION;
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
+    private static final String USER_AGENT_APP_NAME = "kpl";
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.
@@ -39,11 +40,14 @@ public final class GlueSchemaRegistrySerializerInstance {
 
     private GlueSchemaRegistryConfiguration getConfigFromKinesisProducerConfig(
         KinesisProducerConfiguration configuration) {
-        if (configuration.getGlueSchemaRegistryConfiguration() == null) {
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = configuration.getGlueSchemaRegistryConfiguration();
+        if (glueSchemaRegistryConfiguration == null) {
             //Reuse the region from KinesisProducerConfiguration.
-            return new GlueSchemaRegistryConfiguration(configuration.getRegion());
+            glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(configuration.getRegion());
         }
 
-        return configuration.getGlueSchemaRegistryConfiguration();
+        glueSchemaRegistryConfiguration.setUserAgentApp(USER_AGENT_APP_NAME);
+
+        return glueSchemaRegistryConfiguration;
     }
 }


### PR DESCRIPTION
*Description of changes:*

Sets "kpl" as UserAgentApp config in configuration. This allows the Glue Schema Registry library to emit metrics.

*Testing*

Build successful.

Sample UserAgent emitted,
```
autoreg/0:compress/0:secdeser/0:app/kpl-0.14.9/1.1.3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
