### PR TITLE
Upgrading logback-classic from 1.2.0 to 1.2.6

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.6</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrading version of logback classic for [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929). 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
