### PR TITLE
Fixing build issues due to stale CA certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
         - echo "Installing Dependencies for Linux/x86_64"
         - echo "################################################################################"
         - sudo apt-get update
+        - sudo apt-get install -y ca-certificates
         - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" 
         - unzip awscliv2.zip
         - sudo ./aws/install
@@ -54,6 +55,7 @@ matrix:
         - echo "Installing Dependencies for Linux/arm64"
         - echo "################################################################################"
         - sudo apt-get update
+        - sudo apt-get install -y ca-certificates
         - sudo apt-get install python3
         - sudo apt-get -y install python3-pip
         - pip3 --version

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,6 +17,7 @@ LIB_BOOST="http://sourceforge.net/projects/boost/files/boost/1.76.0/boost_1_76_0
 LIB_ZLIB="https://zlib.net/fossils/zlib-1.2.11.tar.gz"
 LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protobuf-all-3.11.4.tar.gz"
 LIB_CURL="https://curl.haxx.se/download/curl-7.77.0.tar.gz"
+CA_CERT="https://curl.haxx.se/ca/cacert.pem"
 
 
 INSTALL_DIR=$(pwd)/third_party
@@ -84,10 +85,11 @@ fi
 # have MD4, which curl tries to use.
 function _curl {
   #(unset LD_LIBRARY_PATH; curl -L $@)
-  curl -L $@
+  curl -L --cacert "$INSTALL_DIR/cacert.pem" $@
 }
 
 cd $INSTALL_DIR
+wget -P $INSTALL_DIR $CA_CERT
 
 function conf {
   if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CI has been failing since curl breaks if the system's CA cert is stale. Adding a step in the build scripts to pull the latest CA cert and use that for the curl requests that the build script uses.


Before:
```
curl: (60) The certificate issuer's certificate has expired.  Check your system date and time.
More details here: http://curl.haxx.se/docs/sslcerts.html
```

Currently this passes, tested this by running the build script on a AL2012 host and verifying the bootstrap script is able to pull dependencies via curl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
