### PR TITLE
Install wget for bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
         - echo "################################################################################"
         - sudo apt-get update
         - sudo apt-get install -y ca-certificates
+        - sudo apt-get install -y wget
         - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" 
         - unzip awscliv2.zip
         - sudo ./aws/install


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix travis build error `./bootstrap.sh: line 92: wget: command not found` in https://app.travis-ci.com/github/awslabs/amazon-kinesis-producer/jobs/553900251


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
