### PR TITLE
Fix GSR test errors

### DIFF
--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstanceTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstanceTest.java
@@ -3,7 +3,9 @@ package com.amazonaws.services.kinesis.producer;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializer;
 import org.junit.Test;
+import java.util.Properties;
 
+import static com.amazonaws.services.kinesis.producer.TestHelper.writeFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -14,8 +16,7 @@ public class GlueSchemaRegistrySerializerInstanceTest {
 
     @Test
     public void testGet_Returns_SingletonInstance() {
-        KinesisProducerConfiguration configuration = new KinesisProducerConfiguration();
-        configuration.setRegion(REGION);
+        KinesisProducerConfiguration configuration = createKPLConfiguration();
 
         GlueSchemaRegistrySerializer serializer1 =
             glueSchemaRegistrySerializerInstance.get(configuration);
@@ -29,12 +30,21 @@ public class GlueSchemaRegistrySerializerInstanceTest {
 
     @Test
     public void testGet_Returns_WhenGlueConfigurationIsExplicitlyConfigured() {
-        KinesisProducerConfiguration configuration = new KinesisProducerConfiguration();
-        configuration.setGlueSchemaRegistryConfiguration(new GlueSchemaRegistryConfiguration(REGION));
+        KinesisProducerConfiguration configuration = createKPLConfiguration();
 
         GlueSchemaRegistrySerializer serializer =
             glueSchemaRegistrySerializerInstance.get(configuration);
 
         assertNotNull(serializer);
+    }
+
+    private KinesisProducerConfiguration createKPLConfiguration() {
+        Properties property = new Properties();
+        property.put("region", REGION);
+        String glueSchemaRegistryPropertyFilePath = writeFile(property);
+
+        Properties kinesisProducerProperties = new Properties();
+        kinesisProducerProperties.put("GlueSchemaRegistryPropertiesFilePath", glueSchemaRegistryPropertyFilePath);
+        return KinesisProducerConfiguration.fromPropertiesFile(writeFile(kinesisProducerProperties));
     }
 }

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/TestHelper.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/TestHelper.java
@@ -1,0 +1,36 @@
+package com.amazonaws.services.kinesis.producer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+
+public class TestHelper {
+    public static String writeFile(String contents) {
+        try {
+            File tmpFile = File.createTempFile(UUID.randomUUID().toString(), ".tmp");
+            tmpFile.deleteOnExit();
+
+            FileWriter writer = new FileWriter(tmpFile);
+            writer.write(contents);
+            writer.close();
+
+            return tmpFile.getAbsolutePath();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String writeFile(Properties p) {
+        try {
+            ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+            p.store(byteOutStream, "");
+            byteOutStream.close();
+            return writeFile(byteOutStream.toString("UTF-8"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Trying to fix travis build errors

```
Tests in error: 

  testGet_Returns_WhenGlueConfigurationIsExplicitlyConfigured(com.amazonaws.services.kinesis.producer.GlueSchemaRegistrySerializerInstanceTest)

  testGet_Returns_SingletonInstance(com.amazonaws.services.kinesis.producer.GlueSchemaRegistrySerializerInstanceTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  simpleTest(com.amazonaws.services.kinesis.producer.FileAgeManagerTest): 

  missingFileTest(com.amazonaws.services.kinesis.producer.FileAgeManagerTest): 

  setThreadPoolSizeFromProperties(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  unknownProperty(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  setThreadingModelToPerRequestFromProperties(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  loadBoolean(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  loadString(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  setThreadingModelToPooledFromProperties(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  setGlueSchemaRegistryConfigFromProperties(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  setGlueSchemaRegistryCredentialsProvider(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  loadLong(com.amazonaws.services.kinesis.producer.KinesisProducerConfigurationTest): Could not initialize class com.amazonaws.auth.DefaultAWSCredentialsProviderChain

  multipleInstances(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Could not initialize class groovy.lang.GroovySystem

  multipleInstances(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Cannot invoke "com.confluex.mock.http.MockHttpsServer.stop()" because "this.server" is null

  differentCredsForRecordsAndMetrics(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Could not initialize class groovy.lang.GroovySystem

  differentCredsForRecordsAndMetrics(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Cannot invoke "com.confluex.mock.http.MockHttpsServer.stop()" because "this.server" is null

  rotatingCredentials(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Could not initialize class groovy.lang.GroovySystem

  rotatingCredentials(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Cannot invoke "com.confluex.mock.http.MockHttpsServer.stop()" because "this.server" is null

  schemaIntegration_OnInvalidSchema_ThrowsException(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Could not initialize class groovy.lang.GroovySystem

  schemaIntegration_OnInvalidSchema_ThrowsException(com.amazonaws.services.kinesis.producer.KinesisProducerTest): Cannot invoke "com.confluex.mock.http.MockHttpsServer.stop()" because "this.server" is null
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
