### PR TITLE
Upgrade the dependencies used in bootstrap + Java dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /bin
 /third_party
 /java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/**/*
+
+# VS Code
+.vscode/

--- a/aws/kinesis/main.cc
+++ b/aws/kinesis/main.cc
@@ -52,7 +52,7 @@ struct {
   std::string ca_path;
   int enable_stack_trace = 0;
   Aws::Utils::Logging::LogLevel aws_log_level = Aws::Utils::Logging::LogLevel::Warn;
-  boost::log::trivial::severity_level boost_log_level = boost::log::trivial::info;
+  boost::log::trivial::severity_level boost_log_level = boost::log::trivial::warning;
 } options;
 
 struct option long_opts[]{
@@ -78,6 +78,7 @@ void handle_log_level(std::string input_level) {
     level_mapping["debug"] = std::make_pair(AwsLog::Debug, BoostLog::debug);
     level_mapping["info"] = std::make_pair(AwsLog::Info, BoostLog::info);
     level_mapping["warn"] = std::make_pair(AwsLog::Warn, BoostLog::warning);
+    level_mapping["warning"] = std::make_pair(AwsLog::Warn, BoostLog::warning);  // to fix issue #137
     level_mapping["error"] = std::make_pair(AwsLog::Error, BoostLog::error);
     level_mapping["fatal"] = std::make_pair(AwsLog::Fatal, BoostLog::fatal);
     //

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,23 +5,31 @@ set -x
 SILENT="y"
 
 silence() {
-    if [ -n "$SILENT" ]; then
-        "$@" > /dev/null
-    else
-        "$@"
-    fi
+  if [ -n "$SILENT" ]; then
+    "$@" >/dev/null
+  else
+    "$@"
+  fi
 }
 
-LIB_OPENSSL="https://ftp.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz"
-LIB_BOOST="http://sourceforge.net/projects/boost/files/boost/1.76.0/boost_1_76_0.tar.gz"
-LIB_ZLIB="https://zlib.net/fossils/zlib-1.2.11.tar.gz"
-LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protobuf-all-3.11.4.tar.gz"
-LIB_CURL="https://curl.haxx.se/download/curl-7.81.0.tar.gz"
-CA_CERT="https://curl.haxx.se/ca/cacert.pem"
+OPENSSL_VERSION="1.1.1q"
+BOOST_VERSION="1.80.0"
+BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.80.0 to 1_80_0
+ZLIB_VERSION="1.2.12"
+PROTOBUF_VERSION="3.11.4"
+CURL_VERSION="7.85.0"
+AWS_SDK_CPP_VERSION="1.9.67"
 
+LIB_OPENSSL="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+LIB_BOOST="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"
+LIB_ZLIB="https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz"
+LIB_CURL="https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz"
+CA_CERT="https://curl.se/ca/cacert.pem"
 
 INSTALL_DIR=$(pwd)/third_party
-#Cleanup any earlier version of the third party directory and links to it.
+
+# Cleanup any earlier version of the third party directory and links to it.
 rm -f b2
 rm -rf $INSTALL_DIR
 mkdir -p $INSTALL_DIR
@@ -30,29 +38,28 @@ mkdir -p $INSTALL_DIR
 # of the native binary
 function find_release_type() {
   if [[ $OSTYPE == "linux-gnu" ]]; then
-		echo "linux-$(uname -m)"
-		return
-	elif [[ $OSTYPE == darwin* ]]; then
-		echo "osx"
-		return
-	elif [[ $OSTYPE == "msys" ]]; then
-		echo "windows"
-		return
-	fi
+    echo "linux-$(uname -m)"
+    return
+  elif [[ $OSTYPE == darwin* ]]; then
+    echo "osx"
+    return
+  elif [[ $OSTYPE == "msys" ]]; then
+    echo "windows"
+    return
+  fi
 
-	echo "unknown"
+  echo "unknown"
 }
 
-CMAKE=$(which cmake3 &> /dev/null && echo "cmake3 " || echo "cmake")
+CMAKE=$(which cmake3 &>/dev/null && echo "cmake3 " || echo "cmake")
 RELEASE_TYPE=$(find_release_type)
 
 [[ $RELEASE_TYPE == "unknown" ]] && {
-	echo "Could not define release type for $OSTYPE"
-	exit 1
+  echo "Could not define release type for $OSTYPE"
+  exit 1
 }
 
-
-if [ $1 == "clang" ] || [ $(uname) == 'Darwin' ]; then
+if [ "$1" == "clang" ] || [ "$(uname)" == 'Darwin' ]; then
   export MACOSX_DEPLOYMENT_TARGET='10.13'
   export MACOSX_MIN_COMPILER_OPT="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
   export CC=$(which clang)
@@ -61,7 +68,7 @@ if [ $1 == "clang" ] || [ $(uname) == 'Darwin' ]; then
   export CFLAGS="${MACOSX_MIN_COMPILER_OPT} "
   export C_INCLUDE_PATH="$INSTALL_DIR/include"
 
-  if [ $(uname) == 'Linux' ]; then
+  if [ "$(uname)" == 'Linux' ]; then
     export LDFLAGS="-L$INSTALL_DIR/lib -nodefaultlibs -lpthread -ldl -lc++ -lc++abi -lm -lc -lgcc_s"
     export LD_LIBRARY_PATH="$INSTALL_DIR/lib:$LD_LIBRARY_PATH"
   else
@@ -94,38 +101,42 @@ wget --no-check-certificate -P $INSTALL_DIR $CA_CERT
 function conf {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     silence ./configure \
-    --prefix="$INSTALL_DIR" \
-    DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH" \
-    LDFLAGS="$LDFLAGS" \
-    CXXFLAGS="$CXXFLAGS" \
-    $@
+      --prefix="$INSTALL_DIR" \
+      DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH" \
+      LDFLAGS="$LDFLAGS" \
+      CXXFLAGS="$CXXFLAGS" \
+      $@
   else
     silence ./configure \
-    --prefix="$INSTALL_DIR" \
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
-    LDFLAGS="$LDFLAGS" \
-    CXXFLAGS="$CXXFLAGS" \
-    C_INCLUDE_PATH="$C_INCLUDE_PATH" \
-    $@
+      --prefix="$INSTALL_DIR" \
+      LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
+      LDFLAGS="$LDFLAGS" \
+      CXXFLAGS="$CXXFLAGS" \
+      C_INCLUDE_PATH="$C_INCLUDE_PATH" \
+      $@
   fi
 }
 
 # OpenSSL
-if [ ! -d "openssl-1.0.2u" ]; then
-  _curl "$LIB_OPENSSL" > openssl.tgz
+if [ ! -d "openssl-${OPENSSL_VERSION}" ]; then
+  _curl "$LIB_OPENSSL" >openssl.tgz
   tar xf openssl.tgz
   rm openssl.tgz
 
-  cd openssl-1.0.2u
+  cd openssl-${OPENSSL_VERSION}
 
   # Have to leave MD4 enabled because curl expects it
-  OPTS="threads no-shared no-idea no-camellia no-seed no-bf no-cast no-rc2 no-rc4 no-rc5 no-md2 no-ripemd no-mdc2 no-ssl2 no-ssl3 no-krb5 no-jpake no-capieng no-dso"
+  OPTS="threads no-shared no-idea no-camellia no-seed no-bf no-cast no-rc2 no-rc5 no-md2 no-mdc2 no-ssl2 no-ssl3 no-capieng no-dso"
 
   if [[ $(uname) == 'Darwin' ]]; then
     silence ./Configure darwin64-x86_64-cc $OPTS --prefix=$INSTALL_DIR
   elif [[ $(uname) == MINGW* ]]; then
     silence ./Configure mingw64 $OPTS --prefix=$INSTALL_DIR
-    find ./ -name Makefile | while read f; do echo >> $f; echo "%.o: %.c" >> $f; echo -e '\t$(COMPILE.c) $(OUTPUT_OPTION) $<;' >> $f; done
+    find ./ -name Makefile | while read f; do
+      echo >>$f
+      echo "%.o: %.c" >>$f
+      echo -e '\t$(COMPILE.c) $(OUTPUT_OPTION) $<;' >>$f
+    done
   else
     silence ./config $OPTS --prefix=$INSTALL_DIR
   fi
@@ -138,12 +149,12 @@ if [ ! -d "openssl-1.0.2u" ]; then
 fi
 
 # Boost C++ Libraries
-if [ ! -d "boost_1_76_0" ]; then
-  _curl "$LIB_BOOST" > boost.tgz
+if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
+  _curl "$LIB_BOOST" >boost.tgz
   tar xf boost.tgz
   rm boost.tgz
 
-  cd boost_1_76_0
+  cd boost_${BOOST_VERSION_UNDERSCORED}
 
   LIBS="atomic,chrono,log,system,test,random,regex,thread,filesystem"
   OPTS="-j 8 --build-type=minimal --layout=system --prefix=$INSTALL_DIR link=static threading=multi release install"
@@ -169,12 +180,12 @@ if [ ! -d "boost_1_76_0" ]; then
 fi
 
 # zlib
-if [ ! -d "zlib-1.2.11" ]; then
-  _curl "$LIB_ZLIB" > zlib.tgz
+if [ ! -d "zlib-${ZLIB_VERSION}" ]; then
+  _curl "$LIB_ZLIB" >zlib.tgz
   tar xf zlib.tgz
   rm zlib.tgz
 
-  cd zlib-1.2.11
+  cd zlib-${ZLIB_VERSION}
   silence ./configure --static --prefix="$INSTALL_DIR"
   silence make -j
   silence make install
@@ -183,12 +194,12 @@ if [ ! -d "zlib-1.2.11" ]; then
 fi
 
 # Google Protocol Buffers
-if [ ! -d "protobuf-3.11.4" ]; then
-  _curl "$LIB_PROTOBUF" > protobuf.tgz
+if [ ! -d "protobuf-${PROTOBUF_VERSION}" ]; then
+  _curl "$LIB_PROTOBUF" >protobuf.tgz
   tar xf protobuf.tgz
   rm protobuf.tgz
 
-  cd protobuf-3.11.4
+  cd protobuf-${PROTOBUF_VERSION}
   silence conf --enable-shared=no
   silence make -j 4
   silence make install
@@ -196,18 +207,16 @@ if [ ! -d "protobuf-3.11.4" ]; then
   cd ..
 fi
 
-
 # libcurl
-if [ ! -d "curl-7.81.0" ]; then
-  _curl "$LIB_CURL" > curl.tgz
+if [ ! -d "curl-${CURL_VERSION}" ]; then
+  _curl "$LIB_CURL" >curl.tgz
   tar xf curl.tgz
   rm curl.tgz
 
-
-  cd curl-7.81.0
+  cd curl-${CURL_VERSION}
 
   silence conf --disable-shared --disable-ldap --disable-ldaps --without-libidn2 \
-       --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-ssl="${INSTALL_DIR}" --without-libidn
+    --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-ssl="${INSTALL_DIR}" --without-libidn
   if [[ $(uname) == 'Darwin' ]]; then
     #
     # Apply a patch for macOS that should prevent curl from trying to use clock_gettime
@@ -226,7 +235,8 @@ fi
 if [ ! -d "aws-sdk-cpp" ]; then
   git clone https://github.com/awslabs/aws-sdk-cpp.git aws-sdk-cpp
   pushd aws-sdk-cpp
-  git checkout 1.8.30
+  git checkout ${AWS_SDK_CPP_VERSION}
+  git submodule update --init --recursive
   popd
 
   rm -rf aws-sdk-cpp-build
@@ -255,7 +265,7 @@ fi
 
 cd ..
 
-#Build the native kinesis producer
+# Build the native kinesis producer
 $CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" .
 make -j8
 
@@ -264,12 +274,10 @@ NATIVE_BINARY_DIR=java/amazon-kinesis-producer/src/main/resources/amazon-kinesis
 mkdir -p $NATIVE_BINARY_DIR
 cp kinesis_producer $NATIVE_BINARY_DIR
 
-
 #build the java producer and install it locally
 pushd java/amazon-kinesis-producer
 mvn clean package source:jar javadoc:jar install
 popd
-
 
 set +e
 set +x

--- a/java/amazon-kinesis-producer-sample/.gitignore
+++ b/java/amazon-kinesis-producer-sample/.gitignore
@@ -1,1 +1,3 @@
 /target/
+*.iml
+.idea/

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -39,13 +39,13 @@
     </build>
     <name>KinesisProducerLibrary Sample Application</name>
     <properties>
-        <aws-java-sdk.version>1.11.960</aws-java-sdk.version>
+        <aws-java-sdk.version>1.12.296</aws-java-sdk.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
-            <version>1.11.2</version>
+            <version>1.14.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
@@ -56,12 +56,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.14.12</version>
+            <version>0.14.13-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>2.0.0.Final</version>
+            <version>2.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -1,16 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.14.12</version>
+    <version>0.14.13-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>
         <url>https://github.com/awslabs/amazon-kinesis-producer.git</url>
     </scm>
 
-    <description>The Amazon Kinesis Producer Library for Java enables developers to easily and reliably put data into Amazon Kinesis.</description>
+    <description>The Amazon Kinesis Producer Library for Java enables developers to easily and reliably put data into
+        Amazon Kinesis.
+    </description>
 
     <url>https://aws.amazon.com/kinesis</url>
 
@@ -18,7 +20,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -27,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.4.1</version>
                 <configuration>
                     <excludePackageNames>com.amazonaws.services.kinesis.producer.protobuf</excludePackageNames>
                 </configuration>
@@ -43,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -57,29 +59,29 @@
     </build>
 
     <properties>
-        <aws-sdk-core-version>1.11.960</aws-sdk-core-version>
+        <aws-sdk-core-version>1.12.296</aws-sdk-core-version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>31.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.16.1</version>
+            <version>3.21.5</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -94,48 +96,36 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.9</version>
+            <version>1.1.13</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
+            <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.confluex</groupId>
-            <artifactId>confluex-mock-http</artifactId>
-            <version>0.4.3</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>5.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.22</version>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <developers>

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/CertificateExtractorTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/CertificateExtractorTest.java
@@ -14,10 +14,6 @@
  */
 package com.amazonaws.services.kinesis.producer;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -26,15 +22,19 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.matchers.JUnitMatchers.hasItem;
 
 public class CertificateExtractorTest {
 
@@ -53,11 +53,11 @@ public class CertificateExtractorTest {
     public void testDirectoryExistsOnExtractionWithMismatch() throws Exception {
         File tempDirectory = Files.createTempDirectory("kpl-ca-test").toFile();
         File caDirectory = new File(tempDirectory, CertificateExtractor.CA_CERTS_DIRECTORY_NAME);
-        assertThat(caDirectory.mkdirs(), equalTo(true));
+        assertTrue(caDirectory.mkdirs());
         File existingCert = new File(caDirectory, CertificateExtractor.CERTIFICATE_FILES.get(5));
 
         try (FileOutputStream fos = new FileOutputStream(existingCert)) {
-            fos.write(new byte[]{1, 2, 3, 4});
+            fos.write(new byte[] { 1, 2, 3, 4 });
         }
 
         CertificateExtractor extractor = new CertificateExtractor();
@@ -70,22 +70,20 @@ public class CertificateExtractorTest {
         ClassLoader classLoader = CertificateExtractor.class.getClassLoader();
 
         Set<File> extractedCertificates = new HashSet<>(extractor.getExtractedCertificates());
-
-        assertThat(extractedCertificates.size(), equalTo(extractor.getExtractedCertificates().size()));
+        assertEquals(extractedCertificates.size(), extractor.getExtractedCertificates().size());
 
         for (String expectedCert : CertificateExtractor.CERTIFICATE_FILES) {
             File resourceFile = new File(CertificateExtractor.CA_CERTS_DIRECTORY_NAME, expectedCert);
 
             InputStream is = classLoader.getResourceAsStream(resourceFile.getPath());
-            assertThat(is, notNullValue());
+            assertNotNull(is);
             List<String> expectedCertLines = IOUtils.readLines(is, Charsets.UTF_8);
 
             File actualCaFile = new File(caCertsDirectory, expectedCert);
             List<String> actualCertLines = Files.readAllLines(actualCaFile.toPath(), Charsets.UTF_8);
 
-            assertThat(extractedCertificates, Matchers.hasItem(actualCaFile.getAbsoluteFile()));
-
-            assertThat(actualCertLines, equalTo(expectedCertLines));
+            assertThat(extractedCertificates, hasItem(actualCaFile.getAbsoluteFile()));
+            assertEquals(expectedCertLines, actualCertLines);
         }
     }
 

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
@@ -246,7 +246,8 @@ public class KinesisProducerTest {
                 .setRegion("us-west-1")
                 .setRecordTtl(200)
                 .setMetricsUploadDelay(100)
-                .setRecordTtl(100);
+                .setRecordTtl(100)
+                .setLogLevel("warning");
         if (provider != null) {
             cfg.setCredentialsProvider(provider);
         }

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
@@ -15,14 +15,24 @@
 
 package com.amazonaws.services.kinesis.producer;
 
-import static com.confluex.mock.http.matchers.HttpMatchers.anyRequest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
+import com.amazonaws.services.schemaregistry.common.Schema;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.socket.PortFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.glue.model.DataFormat;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,151 +41,151 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
-import com.amazonaws.services.schemaregistry.common.Schema;
-import org.apache.commons.lang.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.internal.StaticCredentialsProvider;
-import com.confluex.mock.http.ClientRequest;
-import com.confluex.mock.http.MockHttpsServer;
-import com.google.common.collect.ImmutableList;
-import software.amazon.awssdk.services.glue.model.DataFormat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 public class KinesisProducerTest {
     private static final Logger log = LoggerFactory.getLogger(KinesisProducerTest.class);
-    
-    private MockHttpsServer server;
-    private int port;
-    
+
+    private static final int port = PortFactory.findFreePort();
+    private ClientAndServer mockServer;
+
     private static class RotatingAwsCredentialsProvider implements AWSCredentialsProvider {
         private final List<AWSCredentials> creds;
         private final AtomicInteger idx = new AtomicInteger(0);
-        
+
         public RotatingAwsCredentialsProvider(List<AWSCredentials> creds) {
             this.creds = creds;
         }
-        
+
         @Override
         public AWSCredentials getCredentials() {
             return creds.get(idx.getAndIncrement() % creds.size());
         }
 
         @Override
-        public void refresh() { }
+        public void refresh() {
+        }
     }
-    
+
     @Before
     public void startServer() {
-        server = new MockHttpsServer();
-        port = server.getPort();
-        server.respondTo(anyRequest()).withStatus(403).withBody("(test)");
+        mockServer = startClientAndServer(port);
+        mockServer.when(
+                request()
+        ).respond(
+                response()
+                        .withStatusCode(403)
+                        .withBody("{\"status\":\"Expected error\",\"message\":\"test\"}")
+        );
     }
-    
+
     @After
     public void stopServer() {
-        server.stop();
+        mockServer.stop();
     }
-    
+
     @Test
     public void differentCredsForRecordsAndMetrics() throws InterruptedException, ExecutionException {
         final String AKID_A = "AKIAAAAAAAAAAAAAAAAA";
         final String AKID_B = "AKIABBBBBBBBBBBBBBBB";
-        
+
         final KinesisProducer kp = getProducer(
                 new StaticCredentialsProvider(
                         new BasicAWSCredentials(AKID_A, StringUtils.repeat("a", 40))),
                 new StaticCredentialsProvider(
                         new BasicAWSCredentials(AKID_B, StringUtils.repeat("b", 40))));
-        
+
         final long start = System.nanoTime();
         while (System.nanoTime() - start < 500 * 1000000) {
-            kp.addUserRecord("a", "a", ByteBuffer.wrap(new byte[0]));
+            kp.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
             kp.flush();
             Thread.sleep(10);
         }
-        
+
         kp.flushSync();
         kp.destroy();
-        
-        Map<String, AtomicInteger> counts = new HashMap<String, AtomicInteger>();
+
+        Map<String, AtomicInteger> counts = new HashMap<>();
         counts.put(AKID_A, new AtomicInteger(0));
         counts.put(AKID_B, new AtomicInteger(0));
-        
-        for (ClientRequest cr : server.getRequests()) {
-            String auth = cr.getHeaders().get("Authorization");
-            if (auth == null) {
-                auth = cr.getHeaders().get("authorization");
-            }
-            String host = cr.getHeaders().get("Host");
-            if (host == null) {
-                cr.getHeaders().get("host");
-            }
-            if (auth.contains(AKID_B)) {
-                assertFalse(host.contains("kinesis"));
-                counts.get(AKID_B).getAndIncrement();
-            } else if (auth.contains(AKID_A)) {
-                assertFalse(host.contains("monitoring"));
-                counts.get(AKID_A).getAndIncrement();
-            } else {
-                fail("Expected AKID(s) not found in auth header");
-            }
-        }
-        
+
+        Arrays.stream(mockServer.retrieveRecordedRequests(request())).forEach(
+                httpRequest -> {
+                    String auth = Stream.of("Authorization", "authorization")
+                            .map(headKey -> httpRequest.getHeaders().getValues(headKey).toString())
+                            .findFirst().get();
+                    String host = Stream.of("Host", "host")
+                            .map(headKey -> httpRequest.getHeaders().getValues(headKey).toString())
+                            .findFirst().get();
+                    if (auth.contains(AKID_B)) {
+                        assertFalse(host.contains("kinesis"));
+                        counts.get(AKID_B).getAndIncrement();
+                    } else if (auth.contains(AKID_A)) {
+                        assertFalse(host.contains("monitoring"));
+                        counts.get(AKID_A).getAndIncrement();
+                    } else {
+                        fail("Expected AKID(s) not found in auth header");
+                    }
+                }
+        );
+
         assertTrue(counts.get(AKID_A).get() > 1);
         assertTrue(counts.get(AKID_B).get() > 1);
     }
-    
+
     @Test
     public void rotatingCredentials() throws InterruptedException, ExecutionException {
         final String AKID_C = "AKIACCCCCCCCCCCCCCCC";
         final String AKID_D = "AKIDDDDDDDDDDDDDDDDD";
-        
+
         final KinesisProducer kp = getProducer(
                 new RotatingAwsCredentialsProvider(ImmutableList.<AWSCredentials>of(
                         new BasicAWSCredentials(AKID_C, StringUtils.repeat("c", 40)),
                         new BasicAWSCredentials(AKID_D, StringUtils.repeat("d", 40)))),
                 null);
-        
+
         final long start = System.nanoTime();
         while (System.nanoTime() - start < 500 * 1000000) {
-            kp.addUserRecord("a", "a", ByteBuffer.wrap(new byte[0]));
+            kp.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
             kp.flush();
             Thread.sleep(10);
         }
-        
+
         kp.flushSync();
         kp.destroy();
 
         Map<String, AtomicInteger> counts = new HashMap<String, AtomicInteger>();
         counts.put(AKID_C, new AtomicInteger(0));
         counts.put(AKID_D, new AtomicInteger(0));
-        
-        for (ClientRequest cr : server.getRequests()) {
-            String auth = cr.getHeaders().get("Authorization");
-            if (auth == null) {
-                auth = cr.getHeaders().get("authorization");
-            }
-            if (auth.contains(AKID_C)) {
-                counts.get(AKID_C).getAndIncrement();
-            } else if (auth.contains(AKID_D)) {
-                counts.get(AKID_D).getAndIncrement();
-            } else {
-                fail("Expected AKID(s) not found in auth header");
-            }
-        }
-        
+
+        Arrays.stream(mockServer.retrieveRecordedRequests(request())).forEach(
+                httpRequest -> {
+                    String auth = Stream.of("Authorization", "authorization")
+                            .map(headKey -> httpRequest.getHeaders().getValues(headKey).toString())
+                            .findFirst().get();
+                    if (auth.contains(AKID_C)) {
+                        counts.get(AKID_C).getAndIncrement();
+                    } else if (auth.contains(AKID_D)) {
+                        counts.get(AKID_D).getAndIncrement();
+                    } else {
+                        fail("Expected AKID(s) not found in auth header");
+                    }
+                }
+        );
+
         assertTrue(counts.get(AKID_C).get() > 1);
         assertTrue(counts.get(AKID_D).get() > 1);
     }
-    
+
     @Test
     public void multipleInstances() throws Exception {
         int N = 8;
@@ -210,7 +220,7 @@ public class KinesisProducerTest {
         String stream = "testStream";
         String partitionKey = "partitionKey";
         String hashKey = null;
-        ByteBuffer data = ByteBuffer.wrap(new byte[] {01, 23, 54});
+        ByteBuffer data = ByteBuffer.wrap(new byte[] { 01, 23, 54 });
         String schemaDefinition = null;
         Schema schema = new Schema(schemaDefinition, DataFormat.AVRO.toString(), "testSchema");
         UserRecord userRecord = new UserRecord(stream, partitionKey, hashKey, data, schema);

--- a/java/amazon-kinesis-producer/src/test/resources/logback-test.xml
+++ b/java/amazon-kinesis-producer/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <!-- to reduce noisy outputs -->
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
*Description of changes:*
1. Enhanced `bootstrap.sh` to make upgrades simpler.
1. Upgraded following libraries used in `bootstrap`
    * boost: 1.76.0 -> 1.80.0
    * zlib: 1.2.11 -> 1.2.12
    * curl: 7.81.0 -> 7.85.0
    * openSSL: 1.0.2u -> 1.1.1q
    * protobuf: unchanged, as the version `3.11.4` is locked
1. Upgraded Java dependencies for `amazon-kinesis-producer/pom.xml`
    * maven-compiler-plugin: 3.1 -> 3.7.0
    * maven-javadoc-plugin: 2.10.3 -> 3.4.1
    * maven-source-plugin: 3.0.1 -> 3.2.1
    * aws-sdk-core: 1.11.960 -> 1.12.296
    * guava: 29.0-jre -> 31.1-jre
    * slf4j-api: 1.7.25 -> 2.0.0
    * protobuf-java: 3.16.1 -> 3.21.5
    * commons-io: 2.7 -> 2.11.0
    * schema-registry-serde: 1.1.9 -> 1.1.13
    * junit: 4.13.1 -> 4.13.2
    * jakarta.xml.bind-api: 2.3.2 -> 4.0.0
    * confluex-mock-http: (removed) 0.4.3
    * mockserver-netty-no-dependencies: (added) 5.13.0
    * mockito-core: 2.2.22 -> 4.7.0
    * logback-classic: 1.2.6 -> 1.3.0
1. Upgraded Java dependencies for `amazon-kinesis-producer-sample/pom.xml`
    * aws-java-sdk: 1.11.960 -> 1.12.296
    * amazon-kinesis-client: 1.11.2 -> 1.14.8
    * slf4j-simple: 1.7.13 -> 2.0.0
    * validation-api: 2.0.0.Final -> 2.0.1.Final

*Testing*
- `bootstrap.sh` can successfully build KPL on Linux x86_64
- `producer-sample` can put records to the testing Kinesis stream

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
