### PR TITLE
Replace javax.xml.* references to jakarta.xml.*

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -25,8 +25,7 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
-import javax.xml.bind.DatatypeConverter;
-
+import jakarta.xml.bind.DatatypeConverter;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -36,7 +36,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 /**
- * Configuration for {@link KinesisProducer}. See each each individual set
+ * Configuration for {@link KinesisProducer}. See each individual set
  * method for details about each parameter.
  */
 public class KinesisProducerConfiguration {

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* The javax.xml.* namespace is no longer available after Java 11, which makes this library unusable in Java >= 11. This PR replaces it with the jakarta ones. As they also work for Java 8, this will not introduce compatibility issues


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
