### PR TITLE
Use sts to construct stream arn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ set(STATIC_LIBS
         boost_chrono)
 
 find_package(Threads)
-find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring)
+find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring sts)
 
 add_library(LibCrypto STATIC IMPORTED)
 set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcrypto.a)

--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -422,6 +422,26 @@ class Configuration : private boost::noncopyable {
       return proxy_password_;
   }
 
+  // Use a custom Sts endpoint.
+  //
+  // Note this does not accept protocols or paths, only host names or ip
+  // addresses. There is no way to disable TLS. The KPL always connects with
+  // TLS.
+  //
+  // Expected pattern: ^([A-Za-z0-9-\\.]+)?$
+  const std::string& sts_endpoint() const noexcept {
+    return sts_endpoint_;
+  }
+
+  // Server port to connect to for STS.
+  //
+  // Default: 443
+  // Minimum: 1
+  // Maximum (inclusive): 65535
+  size_t sts_port() const noexcept {
+    return sts_port_;
+  }
+
   /// Indicates whether the SDK clients should use a thread pool or not
   /// \return true if the client should use a thread pool, false otherwise
   bool use_thread_pool() const noexcept {
@@ -1009,6 +1029,43 @@ class Configuration : private boost::noncopyable {
       return *this;
   }
 
+  // Use a custom STS endpoint.
+  //
+  // Note this does not accept protocols or paths, only host names or ip
+  // addresses. There is no way to disable TLS. The KPL always connects with
+  // TLS.
+  //
+  // Expected pattern: ^([A-Za-z0-9-\\.]+)?$
+  Configuration& sts_endpoint(std::string val) {
+    static std::regex pattern(
+            "^([A-Za-z0-9-\\.]+)?$",
+            std::regex::ECMAScript | std::regex::optimize);
+    if (!std::regex_match(val, pattern)) {
+      std::string err;
+      err += "sts_endpoint must match the pattern ^([A-Za-z0-9-\\.]+)?$, got ";
+      err += val;
+      throw std::runtime_error(err);
+    }
+    sts_endpoint_ = val;
+    return *this;
+  }
+
+  // Server port to connect to for STS.
+  //
+  // Default: 443
+  // Minimum: 1
+  // Maximum (inclusive): 65535
+  Configuration& sts_port(size_t val) {
+    if (val < 1ull || val > 65535ull) {
+      std::string err;
+      err += "sts_port must be between 1 and 65535, got ";
+      err += std::to_string(val);
+      throw std::runtime_error(err);
+    }
+    sts_port_ = val;
+    return *this;
+  }
+
   /// Enables or disable the use of a thread pool for the SDK Client.
   /// Default: false
   /// \param val whether or not to use a thread pool
@@ -1078,6 +1135,9 @@ class Configuration : private boost::noncopyable {
     proxy_port(c.proxy_port());
     proxy_user_name(c.proxy_user_name());
     proxy_password(c.proxy_password());
+    sts_endpoint(c.sts_endpoint());
+    sts_port(c.sts_port());
+
     if (c.thread_config() == ::aws::kinesis::protobuf::Configuration_ThreadConfig::Configuration_ThreadConfig_POOLED) {
       use_thread_pool(true);
       thread_pool_size(c.thread_pool_size());
@@ -1123,6 +1183,8 @@ class Configuration : private boost::noncopyable {
   size_t proxy_port_ = 443;
   std::string proxy_user_name_ = "";
   std::string proxy_password_ = "";
+  std::string sts_endpoint_ = "";
+  size_t sts_port_ = 443;
 
   bool use_thread_pool_ = true;
   uint32_t thread_pool_size_ = 64;

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -33,9 +33,16 @@ namespace {
 struct EndpointConfiguration {
   std::string kinesis_endpoint_;
   std::string cloudwatch_endpoint_;
+  std::string sts_endpoint_;
 
-  EndpointConfiguration(std::string kinesis_endpoint, std::string cloudwatch_endpoint) :
-    kinesis_endpoint_(kinesis_endpoint), cloudwatch_endpoint_(cloudwatch_endpoint) {}
+  EndpointConfiguration(std::string kinesis_endpoint, std::string cloudwatch_endpoint) {
+    EndpointConfiguration(kinesis_endpoint, cloudwatch_endpoint, {});
+  }
+
+  EndpointConfiguration(std::string kinesis_endpoint, std::string cloudwatch_endpoint, std::string sts_endpoint) :
+          kinesis_endpoint_(kinesis_endpoint),
+          cloudwatch_endpoint_(cloudwatch_endpoint),
+          sts_endpoint_(sts_endpoint) {}
 };
 
 const constexpr char* kVersion = "0.14.13N";
@@ -200,6 +207,21 @@ void KinesisProducer::create_cw_client(const std::string& ca_path) {
       cfg);
 }
 
+void KinesisProducer::create_sts_client(const std::string& ca_path) {
+  auto cfg = make_sdk_client_cfg(*config_, region_, ca_path, 2);
+  if (config_->sts_endpoint().size() > 0) {
+    cfg.endpointOverride = config_->sts_endpoint() + ":" +
+                           std::to_string(config_->sts_port());
+    LOG(info) << "Using STS endpoint " + cfg.endpointOverride;
+  } else {
+    set_override_if_present(region_, cfg, "STS", [](auto ep) -> std::string { return ep.sts_endpoint_; });
+  }
+
+  sts_client_ = std::make_shared<Aws::STS::STSClient>(
+          kinesis_creds_provider_,  // STS doesn't require any permissions, so Kinesis cred works here
+          cfg);
+}
+
 Pipeline* KinesisProducer::create_pipeline(const std::string& stream) {
   LOG(info) << "Created pipeline for stream \"" << stream << "\"";
   return new Pipeline(
@@ -209,6 +231,7 @@ Pipeline* KinesisProducer::create_pipeline(const std::string& stream) {
       executor_,
       kinesis_client_,
       metrics_manager_,
+      sts_client_,
       [this](auto& ur) {
         ipc_manager_->put(ur->to_put_record_result().SerializeAsString());
       });

--- a/aws/kinesis/core/kinesis_producer.h
+++ b/aws/kinesis/core/kinesis_producer.h
@@ -52,6 +52,7 @@ class KinesisProducer : boost::noncopyable {
         shutdown_(false) {
     create_kinesis_client(ca_path);
     create_cw_client(ca_path);
+    create_sts_client(ca_path);
     create_metrics_manager();
     report_outstanding();
     message_drainer_ = aws::thread([this] { this->drain_messages(); });
@@ -76,6 +77,8 @@ class KinesisProducer : boost::noncopyable {
   void create_kinesis_client(const std::string& ca_path);
 
   void create_cw_client(const std::string& ca_path);
+
+  void create_sts_client(const std::string& ca_path);
 
   Pipeline* create_pipeline(const std::string& stream);
 
@@ -103,6 +106,7 @@ class KinesisProducer : boost::noncopyable {
       cw_creds_provider_;
   std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client_;
   std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cw_client_;
+  std::shared_ptr<Aws::STS::STSClient> sts_client_;
   std::shared_ptr<aws::utils::Executor> executor_;
 
   std::shared_ptr<IpcManager> ipc_manager_;

--- a/aws/kinesis/core/pipeline.h
+++ b/aws/kinesis/core/pipeline.h
@@ -54,15 +54,17 @@ class Pipeline : boost::noncopyable {
       std::shared_ptr<aws::utils::Executor> executor,
       std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client,
       std::shared_ptr<aws::metrics::MetricsManager> metrics_manager,
+      std::shared_ptr<Aws::STS::STSClient> sts_client,
       Retrier::UserRecordCallback finish_user_record_cb)
       : stream_(std::move(stream)),
         region_(std::move(region)),
-        stream_arn_(std::move(init_stream_arn(region_, stream_))),
+        stream_arn_(std::move(init_stream_arn(sts_client, region_, stream_))),
         config_(std::move(config)),
         stats_logger_(stream_, config_->record_max_buffered_time()),
         executor_(std::move(executor)),
         kinesis_client_(std::move(kinesis_client)),
         metrics_manager_(std::move(metrics_manager)),
+        sts_client_(std::move(sts_client)),
         finish_user_record_cb_(std::move(finish_user_record_cb)),
         shard_map_(
             std::make_shared<ShardMap>(
@@ -201,10 +203,11 @@ class Pipeline : boost::noncopyable {
   }
 
   // Retrieve the account ID and partition from the STS service.
-  static std::string init_stream_arn(const std::string &region, const std::string &stream_name) {
-    Aws::STS::STSClient sts;
+  static std::string init_stream_arn(const std::shared_ptr<Aws::STS::STSClient>& sts_client,
+                                     const std::string &region,
+                                     const std::string &stream_name) {
     Aws::STS::Model::GetCallerIdentityRequest request;
-    auto outcome = sts.GetCallerIdentity(request);
+    auto outcome = sts_client->GetCallerIdentity(request);
     if (outcome.IsSuccess()) {
       auto result = outcome.GetResult();
       Aws::Utils::ARN sts_arn(result.GetArn());
@@ -219,10 +222,13 @@ class Pipeline : boost::noncopyable {
                 << "and will be used in requests including ListShards and PutRecords";
       return arn_str;
     }
-
-    LOG(warning) << "Failed to get StreamARN using STS GetCallerIdentity with exception: "
-              << outcome.GetError().GetMessage().c_str();
-    return {};
+    auto e = outcome.GetError();
+    auto code = e.GetExceptionName();
+    auto msg = e.GetMessage();
+    LOG(error) << "Failed to get StreamARN using STS GetCallerIdentity | Code: " << code
+               << " | Message: " << msg
+               << " | Request was: " << request.SerializePayload();
+    exit(EXIT_FAILURE);
   }
 
   std::string region_;
@@ -233,6 +239,7 @@ class Pipeline : boost::noncopyable {
   std::shared_ptr<aws::utils::Executor> executor_;
   std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client_;
   std::shared_ptr<aws::metrics::MetricsManager> metrics_manager_;
+  std::shared_ptr<Aws::STS::STSClient> sts_client_;
   Retrier::UserRecordCallback finish_user_record_cb_;
 
   std::shared_ptr<ShardMap> shard_map_;

--- a/aws/kinesis/core/put_records_context.h
+++ b/aws/kinesis/core/put_records_context.h
@@ -34,12 +34,18 @@ namespace core {
 class PutRecordsContext : public Aws::Client::AsyncCallerContext {
  public:
   PutRecordsContext(std::string stream,
+                    std::string stream_arn,
                     std::vector<std::shared_ptr<KinesisRecord>> records)
-      : stream_(stream),
+      : stream_(std::move(stream)),
+        stream_arn_(std::move(stream_arn)),
         records_(std::move(records)) {}
 
   const std::string& get_stream() const {
     return stream_;
+  }
+
+  const std::string& get_stream_arn() const {
+    return stream_arn_;
   }
 
   std::chrono::steady_clock::time_point get_start() const {
@@ -76,6 +82,7 @@ class PutRecordsContext : public Aws::Client::AsyncCallerContext {
       req.AddRecords(std::move(e));
     }
     req.SetStreamName(stream_);
+    if (!stream_arn_.empty()) req.SetStreamARN(stream_arn_);
     return req;
   }
 
@@ -96,6 +103,7 @@ class PutRecordsContext : public Aws::Client::AsyncCallerContext {
 
  private:
   std::string stream_;
+  std::string stream_arn_;
   std::chrono::steady_clock::time_point start_;
   std::chrono::steady_clock::time_point end_;
   std::vector<std::shared_ptr<KinesisRecord>> records_;

--- a/aws/kinesis/core/retrier.h
+++ b/aws/kinesis/core/retrier.h
@@ -46,6 +46,7 @@ class MetricsPutter {
  private:
   std::shared_ptr<aws::metrics::MetricsManager> metrics_manager_;
   std::string stream_;
+  std::string stream_arn_;
 };
 
 } // namespace detail

--- a/aws/kinesis/core/shard_map.cc
+++ b/aws/kinesis/core/shard_map.cc
@@ -150,14 +150,14 @@ void ShardMap::list_shards_callback(
   updated_at_ = std::chrono::steady_clock::now();
 
   LOG(info) << "Successfully updated shard map for stream \""
-            << stream_ << (stream_arn_.empty() ? "\"" : "\" (arn: \"" + stream_arn_ + "\")")
-            << ". Found " << end_hash_key_to_shard_id_.size() << " shards";
+            << stream_ << (stream_arn_.empty() ? "\"" : "\" (arn: \"" + stream_arn_ + "\"). Found ")
+            << end_hash_key_to_shard_id_.size() << " shards";
 }
 
 void ShardMap::update_fail(const std::string &code, const std::string &msg) {
   LOG(error) << "Shard map update for stream \""
-             << stream_ << (stream_arn_.empty() ? "\"" : "\" (arn: \"" + stream_arn_ + "\")")
-             << "failed. Code: " << code << " Message: " << msg << "; retrying in "
+             << stream_ << (stream_arn_.empty() ? "\"" : "\" (arn: \"" + stream_arn_ + "\") failed. ")
+             << "Code: " << code << " Message: " << msg << "; retrying in "
              << backoff_.count() << " ms";
 
   WriteLock lock(mutex_);

--- a/aws/kinesis/core/shard_map.h
+++ b/aws/kinesis/core/shard_map.h
@@ -38,6 +38,7 @@ class ShardMap : boost::noncopyable {
   ShardMap(std::shared_ptr<aws::utils::Executor> executor,
            std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client,
            std::string stream,
+           std::string stream_arn,
            std::shared_ptr<aws::metrics::MetricsManager> metrics_manager
               = std::make_shared<aws::metrics::NullMetricsManager>(),
            std::chrono::milliseconds min_backoff = kMinBackoff,
@@ -88,6 +89,7 @@ class ShardMap : boost::noncopyable {
   std::shared_ptr<aws::utils::Executor> executor_;
   std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client_;
   std::string stream_;
+  std::string stream_arn_;
   std::shared_ptr<aws::metrics::MetricsManager> metrics_manager_;
 
   State state_;

--- a/aws/kinesis/core/test/retrier_test.cc
+++ b/aws/kinesis/core/test/retrier_test.cc
@@ -58,6 +58,7 @@ auto make_prr_ctx(size_t num_kr,
   }
   auto ctx = std::make_shared<aws::kinesis::core::PutRecordsContext>(
       "myStream",
+      "arn:aws:kinesis:us-east-2:123456789012:stream/myStream",
       krs);
   ctx->set_outcome(outcome);
   return ctx;

--- a/aws/kinesis/core/test/shard_map_test.cc
+++ b/aws/kinesis/core/test/shard_map_test.cc
@@ -26,6 +26,7 @@
 namespace {
 
 const std::string kStreamName = "myStream";
+const std::string kStreamARN = "arn:aws:kinesis:us-east-2:123456789012:stream/myStream";
 
 Aws::Client::ClientConfiguration fake_client_cfg() {
   Aws::Client::ClientConfiguration cfg;
@@ -88,6 +89,7 @@ class Wrapper {
                 outcomes_list_shards,
                 [this] { num_req_received_++; }),
             kStreamName,
+            kStreamARN,
             std::make_shared<aws::metrics::NullMetricsManager>(),
             std::chrono::milliseconds(100),
             std::chrono::milliseconds(1000));

--- a/aws/kinesis/main.cc
+++ b/aws/kinesis/main.cc
@@ -256,19 +256,15 @@ std::string get_region(const aws::kinesis::core::Configuration& config) {
     return config.region();
   }
 
-  Aws::Internal::EC2MetadataClient ec2_md;
-  auto az = ec2_md.GetResource(
-      "/latest/meta-data/placement/availability-zone/");
-  auto regex = std::regex("^([a-z]+-[a-z]+-[0-9])[a-z]$",
-                          std::regex::ECMAScript);
-  std::smatch m;
-  if (std::regex_match(az, m, regex)) {
-    return m.str(1);
+  Aws::Internal::EC2MetadataClient ec2_client;
+  Aws::String region = ec2_client.GetCurrentRegion();
+  if (region.empty()) {
+    LOG(error) << "Could not configure the region. It was not given in the "
+               << "config and we were unable to retrieve it from EC2 metadata.";
+    throw 1;
   }
 
-  LOG(error) << "Could not configure the region. It was not given in the "
-             << "config and we were unable to retrieve it from EC2 metadata.";
-  throw 1;
+  return region;
 }
 
 std::pair<

--- a/aws/kinesis/protobuf/config.pb.cc
+++ b/aws/kinesis/protobuf/config.pb.cc
@@ -125,44 +125,48 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_config_2eproto::offsets[] PROT
   PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, proxy_port_),
   PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, proxy_user_name_),
   PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, proxy_password_),
+  PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, sts_endpoint_),
+  PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, sts_port_),
   PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, thread_config_),
   PROTOBUF_FIELD_OFFSET(::aws::kinesis::protobuf::Configuration, thread_pool_size_),
   ~0u,
-  23,
-  13,
+  24,
   14,
-  0,
   15,
+  0,
   16,
   17,
   18,
-  10,
-  11,
-  1,
   19,
-  2,
+  11,
+  12,
+  1,
   20,
+  2,
+  21,
   3,
   4,
   5,
-  21,
   22,
-  26,
+  23,
   27,
   28,
-  6,
   29,
-  24,
-  7,
+  6,
   30,
+  25,
+  7,
+  31,
   8,
   9,
-  12,
-  25,
+  10,
+  32,
+  13,
+  26,
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 8, sizeof(::aws::kinesis::protobuf::AdditionalDimension)},
-  { 11, 48, sizeof(::aws::kinesis::protobuf::Configuration)},
+  { 11, 50, sizeof(::aws::kinesis::protobuf::Configuration)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -173,7 +177,7 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
 const char descriptor_table_protodef_config_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023"
   "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu"
-  "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\220\t\n\rConfigu"
+  "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\277\t\n\rConfigu"
   "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132"
   ").aws.kinesis.protobuf.AdditionalDimensi"
   "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n"
@@ -198,13 +202,14 @@ const char descriptor_table_protodef_config_2eproto[] PROTOBUF_SECTION_VARIABLE(
   "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi"
   "ficate\030\031 \001(\010:\004true\022\024\n\nproxy_host\030\032 \001(\t:\000"
   "\022\027\n\nproxy_port\030\033 \001(\004:\003443\022\031\n\017proxy_user_"
-  "name\030\034 \001(\t:\000\022\030\n\016proxy_password\030\035 \001(\t:\000\022T"
-  "\n\rthread_config\030\036 \001(\01620.aws.kinesis.prot"
-  "obuf.Configuration.ThreadConfig:\013PER_REQ"
-  "UEST\022\034\n\020thread_pool_size\030\037 \001(\r:\00264\"+\n\014Th"
-  "readConfig\022\017\n\013PER_REQUEST\020\000\022\n\n\006POOLED\020\001B"
-  "2\n0com.amazonaws.services.kinesis.produc"
-  "er.protobuf"
+  "name\030\034 \001(\t:\000\022\030\n\016proxy_password\030\035 \001(\t:\000\022\026"
+  "\n\014sts_endpoint\030  \001(\t:\000\022\025\n\010sts_port\030! \001(\004"
+  ":\003443\022T\n\rthread_config\030\036 \001(\01620.aws.kines"
+  "is.protobuf.Configuration.ThreadConfig:\013"
+  "PER_REQUEST\022\034\n\020thread_pool_size\030\037 \001(\r:\0026"
+  "4\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST\020\000\022\n\n\006PO"
+  "OLED\020\001B2\n0com.amazonaws.services.kinesis"
+  ".producer.protobuf"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_config_2eproto_deps[1] = {
 };
@@ -215,7 +220,7 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_con
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_config_2eproto_once;
 static bool descriptor_table_config_2eproto_initialized = false;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_config_2eproto = {
-  &descriptor_table_config_2eproto_initialized, descriptor_table_protodef_config_2eproto, "config.proto", 1331,
+  &descriptor_table_config_2eproto_initialized, descriptor_table_protodef_config_2eproto, "config.proto", 1378,
   &descriptor_table_config_2eproto_once, descriptor_table_config_2eproto_sccs, descriptor_table_config_2eproto_deps, 2, 0,
   schemas, file_default_instances, TableStruct_config_2eproto::offsets,
   file_level_metadata_config_2eproto, 2, file_level_enum_descriptors_config_2eproto, file_level_service_descriptors_config_2eproto,
@@ -593,46 +598,46 @@ class Configuration::_Internal {
  public:
   using HasBits = decltype(std::declval<Configuration>()._has_bits_);
   static void set_has_aggregation_enabled(HasBits* has_bits) {
-    (*has_bits)[0] |= 8388608u;
+    (*has_bits)[0] |= 16777216u;
   }
   static void set_has_aggregation_max_count(HasBits* has_bits) {
-    (*has_bits)[0] |= 8192u;
+    (*has_bits)[0] |= 16384u;
   }
   static void set_has_aggregation_max_size(HasBits* has_bits) {
-    (*has_bits)[0] |= 16384u;
+    (*has_bits)[0] |= 32768u;
   }
   static void set_has_cloudwatch_endpoint(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
   }
   static void set_has_cloudwatch_port(HasBits* has_bits) {
-    (*has_bits)[0] |= 32768u;
-  }
-  static void set_has_collection_max_count(HasBits* has_bits) {
     (*has_bits)[0] |= 65536u;
   }
-  static void set_has_collection_max_size(HasBits* has_bits) {
+  static void set_has_collection_max_count(HasBits* has_bits) {
     (*has_bits)[0] |= 131072u;
   }
-  static void set_has_connect_timeout(HasBits* has_bits) {
+  static void set_has_collection_max_size(HasBits* has_bits) {
     (*has_bits)[0] |= 262144u;
   }
+  static void set_has_connect_timeout(HasBits* has_bits) {
+    (*has_bits)[0] |= 524288u;
+  }
   static void set_has_enable_core_dumps(HasBits* has_bits) {
-    (*has_bits)[0] |= 1024u;
+    (*has_bits)[0] |= 2048u;
   }
   static void set_has_fail_if_throttled(HasBits* has_bits) {
-    (*has_bits)[0] |= 2048u;
+    (*has_bits)[0] |= 4096u;
   }
   static void set_has_kinesis_endpoint(HasBits* has_bits) {
     (*has_bits)[0] |= 2u;
   }
   static void set_has_kinesis_port(HasBits* has_bits) {
-    (*has_bits)[0] |= 524288u;
+    (*has_bits)[0] |= 1048576u;
   }
   static void set_has_log_level(HasBits* has_bits) {
     (*has_bits)[0] |= 4u;
   }
   static void set_has_max_connections(HasBits* has_bits) {
-    (*has_bits)[0] |= 1048576u;
+    (*has_bits)[0] |= 2097152u;
   }
   static void set_has_metrics_granularity(HasBits* has_bits) {
     (*has_bits)[0] |= 8u;
@@ -644,34 +649,34 @@ class Configuration::_Internal {
     (*has_bits)[0] |= 32u;
   }
   static void set_has_metrics_upload_delay(HasBits* has_bits) {
-    (*has_bits)[0] |= 2097152u;
-  }
-  static void set_has_min_connections(HasBits* has_bits) {
     (*has_bits)[0] |= 4194304u;
   }
-  static void set_has_rate_limit(HasBits* has_bits) {
-    (*has_bits)[0] |= 67108864u;
+  static void set_has_min_connections(HasBits* has_bits) {
+    (*has_bits)[0] |= 8388608u;
   }
-  static void set_has_record_max_buffered_time(HasBits* has_bits) {
+  static void set_has_rate_limit(HasBits* has_bits) {
     (*has_bits)[0] |= 134217728u;
   }
-  static void set_has_record_ttl(HasBits* has_bits) {
+  static void set_has_record_max_buffered_time(HasBits* has_bits) {
     (*has_bits)[0] |= 268435456u;
+  }
+  static void set_has_record_ttl(HasBits* has_bits) {
+    (*has_bits)[0] |= 536870912u;
   }
   static void set_has_region(HasBits* has_bits) {
     (*has_bits)[0] |= 64u;
   }
   static void set_has_request_timeout(HasBits* has_bits) {
-    (*has_bits)[0] |= 536870912u;
+    (*has_bits)[0] |= 1073741824u;
   }
   static void set_has_verify_certificate(HasBits* has_bits) {
-    (*has_bits)[0] |= 16777216u;
+    (*has_bits)[0] |= 33554432u;
   }
   static void set_has_proxy_host(HasBits* has_bits) {
     (*has_bits)[0] |= 128u;
   }
   static void set_has_proxy_port(HasBits* has_bits) {
-    (*has_bits)[0] |= 1073741824u;
+    (*has_bits)[0] |= 2147483648u;
   }
   static void set_has_proxy_user_name(HasBits* has_bits) {
     (*has_bits)[0] |= 256u;
@@ -679,11 +684,17 @@ class Configuration::_Internal {
   static void set_has_proxy_password(HasBits* has_bits) {
     (*has_bits)[0] |= 512u;
   }
+  static void set_has_sts_endpoint(HasBits* has_bits) {
+    (*has_bits)[0] |= 1024u;
+  }
+  static void set_has_sts_port(HasBits* has_bits) {
+    (*has_bits)[1] |= 1u;
+  }
   static void set_has_thread_config(HasBits* has_bits) {
-    (*has_bits)[0] |= 4096u;
+    (*has_bits)[0] |= 8192u;
   }
   static void set_has_thread_pool_size(HasBits* has_bits) {
-    (*has_bits)[0] |= 33554432u;
+    (*has_bits)[0] |= 67108864u;
   }
 };
 
@@ -742,9 +753,13 @@ Configuration::Configuration(const Configuration& from)
   if (from._internal_has_proxy_password()) {
     proxy_password_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.proxy_password_);
   }
+  sts_endpoint_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (from._internal_has_sts_endpoint()) {
+    sts_endpoint_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.sts_endpoint_);
+  }
   ::memcpy(&enable_core_dumps_, &from.enable_core_dumps_,
-    static_cast<size_t>(reinterpret_cast<char*>(&proxy_port_) -
-    reinterpret_cast<char*>(&enable_core_dumps_)) + sizeof(proxy_port_));
+    static_cast<size_t>(reinterpret_cast<char*>(&sts_port_) -
+    reinterpret_cast<char*>(&enable_core_dumps_)) + sizeof(sts_port_));
   // @@protoc_insertion_point(copy_constructor:aws.kinesis.protobuf.Configuration)
 }
 
@@ -760,6 +775,7 @@ void Configuration::SharedCtor() {
   proxy_host_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   proxy_user_name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   proxy_password_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  sts_endpoint_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   ::memset(&enable_core_dumps_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&thread_config_) -
       reinterpret_cast<char*>(&enable_core_dumps_)) + sizeof(thread_config_));
@@ -781,6 +797,7 @@ void Configuration::SharedCtor() {
   record_ttl_ = PROTOBUF_ULONGLONG(30000);
   request_timeout_ = PROTOBUF_ULONGLONG(6000);
   proxy_port_ = PROTOBUF_ULONGLONG(443);
+  sts_port_ = PROTOBUF_ULONGLONG(443);
 }
 
 Configuration::~Configuration() {
@@ -799,6 +816,7 @@ void Configuration::SharedDtor() {
   proxy_host_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   proxy_user_name_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   proxy_password_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  sts_endpoint_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void Configuration::SetCachedSize(int size) const {
@@ -844,23 +862,26 @@ void Configuration::Clear() {
       proxy_host_.ClearNonDefaultToEmptyNoArena();
     }
   }
-  if (cached_has_bits & 0x00000300u) {
+  if (cached_has_bits & 0x00000700u) {
     if (cached_has_bits & 0x00000100u) {
       proxy_user_name_.ClearNonDefaultToEmptyNoArena();
     }
     if (cached_has_bits & 0x00000200u) {
       proxy_password_.ClearNonDefaultToEmptyNoArena();
     }
+    if (cached_has_bits & 0x00000400u) {
+      sts_endpoint_.ClearNonDefaultToEmptyNoArena();
+    }
   }
-  if (cached_has_bits & 0x0000fc00u) {
+  if (cached_has_bits & 0x0000f800u) {
     ::memset(&enable_core_dumps_, 0, static_cast<size_t>(
         reinterpret_cast<char*>(&thread_config_) -
         reinterpret_cast<char*>(&enable_core_dumps_)) + sizeof(thread_config_));
     aggregation_max_count_ = PROTOBUF_ULONGLONG(4294967295);
     aggregation_max_size_ = PROTOBUF_ULONGLONG(51200);
-    cloudwatch_port_ = PROTOBUF_ULONGLONG(443);
   }
   if (cached_has_bits & 0x00ff0000u) {
+    cloudwatch_port_ = PROTOBUF_ULONGLONG(443);
     collection_max_count_ = PROTOBUF_ULONGLONG(500);
     collection_max_size_ = PROTOBUF_ULONGLONG(5242880);
     connect_timeout_ = PROTOBUF_ULONGLONG(6000);
@@ -868,9 +889,9 @@ void Configuration::Clear() {
     max_connections_ = PROTOBUF_ULONGLONG(24);
     metrics_upload_delay_ = PROTOBUF_ULONGLONG(60000);
     min_connections_ = PROTOBUF_ULONGLONG(1);
-    aggregation_enabled_ = true;
   }
-  if (cached_has_bits & 0x7f000000u) {
+  if (cached_has_bits & 0xff000000u) {
+    aggregation_enabled_ = true;
     verify_certificate_ = true;
     thread_pool_size_ = 64u;
     rate_limit_ = PROTOBUF_ULONGLONG(150);
@@ -879,13 +900,13 @@ void Configuration::Clear() {
     request_timeout_ = PROTOBUF_ULONGLONG(6000);
     proxy_port_ = PROTOBUF_ULONGLONG(443);
   }
+  sts_port_ = PROTOBUF_ULONGLONG(443);
   _has_bits_.Clear();
   _internal_metadata_.Clear();
 }
 
 const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
-  _Internal::HasBits has_bits{};
   while (!ctx->Done(&ptr)) {
     ::PROTOBUF_NAMESPACE_ID::uint32 tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
@@ -894,7 +915,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional bool aggregation_enabled = 1 [default = true];
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
-          _Internal::set_has_aggregation_enabled(&has_bits);
+          _Internal::set_has_aggregation_enabled(&_has_bits_);
           aggregation_enabled_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -902,7 +923,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 aggregation_max_count = 2 [default = 4294967295];
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
-          _Internal::set_has_aggregation_max_count(&has_bits);
+          _Internal::set_has_aggregation_max_count(&_has_bits_);
           aggregation_max_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -910,7 +931,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 aggregation_max_size = 3 [default = 51200];
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
-          _Internal::set_has_aggregation_max_size(&has_bits);
+          _Internal::set_has_aggregation_max_size(&_has_bits_);
           aggregation_max_size_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -929,7 +950,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 cloudwatch_port = 5 [default = 443];
       case 5:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 40)) {
-          _Internal::set_has_cloudwatch_port(&has_bits);
+          _Internal::set_has_cloudwatch_port(&_has_bits_);
           cloudwatch_port_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -937,7 +958,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 collection_max_count = 6 [default = 500];
       case 6:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 48)) {
-          _Internal::set_has_collection_max_count(&has_bits);
+          _Internal::set_has_collection_max_count(&_has_bits_);
           collection_max_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -945,7 +966,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 collection_max_size = 7 [default = 5242880];
       case 7:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 56)) {
-          _Internal::set_has_collection_max_size(&has_bits);
+          _Internal::set_has_collection_max_size(&_has_bits_);
           collection_max_size_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -953,7 +974,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 connect_timeout = 8 [default = 6000];
       case 8:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 64)) {
-          _Internal::set_has_connect_timeout(&has_bits);
+          _Internal::set_has_connect_timeout(&_has_bits_);
           connect_timeout_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -961,7 +982,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional bool enable_core_dumps = 9 [default = false];
       case 9:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 72)) {
-          _Internal::set_has_enable_core_dumps(&has_bits);
+          _Internal::set_has_enable_core_dumps(&_has_bits_);
           enable_core_dumps_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -969,7 +990,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional bool fail_if_throttled = 10 [default = false];
       case 10:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 80)) {
-          _Internal::set_has_fail_if_throttled(&has_bits);
+          _Internal::set_has_fail_if_throttled(&_has_bits_);
           fail_if_throttled_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -988,7 +1009,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 kinesis_port = 12 [default = 443];
       case 12:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 96)) {
-          _Internal::set_has_kinesis_port(&has_bits);
+          _Internal::set_has_kinesis_port(&_has_bits_);
           kinesis_port_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1007,7 +1028,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 max_connections = 14 [default = 24];
       case 14:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 112)) {
-          _Internal::set_has_max_connections(&has_bits);
+          _Internal::set_has_max_connections(&_has_bits_);
           max_connections_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1048,7 +1069,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 metrics_upload_delay = 18 [default = 60000];
       case 18:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 144)) {
-          _Internal::set_has_metrics_upload_delay(&has_bits);
+          _Internal::set_has_metrics_upload_delay(&_has_bits_);
           metrics_upload_delay_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1056,7 +1077,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 min_connections = 19 [default = 1];
       case 19:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 152)) {
-          _Internal::set_has_min_connections(&has_bits);
+          _Internal::set_has_min_connections(&_has_bits_);
           min_connections_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1064,7 +1085,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 rate_limit = 20 [default = 150];
       case 20:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 160)) {
-          _Internal::set_has_rate_limit(&has_bits);
+          _Internal::set_has_rate_limit(&_has_bits_);
           rate_limit_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1072,7 +1093,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 record_max_buffered_time = 21 [default = 100];
       case 21:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 168)) {
-          _Internal::set_has_record_max_buffered_time(&has_bits);
+          _Internal::set_has_record_max_buffered_time(&_has_bits_);
           record_max_buffered_time_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1080,7 +1101,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 record_ttl = 22 [default = 30000];
       case 22:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 176)) {
-          _Internal::set_has_record_ttl(&has_bits);
+          _Internal::set_has_record_ttl(&_has_bits_);
           record_ttl_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1099,7 +1120,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 request_timeout = 24 [default = 6000];
       case 24:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 192)) {
-          _Internal::set_has_request_timeout(&has_bits);
+          _Internal::set_has_request_timeout(&_has_bits_);
           request_timeout_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1107,7 +1128,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional bool verify_certificate = 25 [default = true];
       case 25:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 200)) {
-          _Internal::set_has_verify_certificate(&has_bits);
+          _Internal::set_has_verify_certificate(&_has_bits_);
           verify_certificate_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1126,7 +1147,7 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint64 proxy_port = 27 [default = 443];
       case 27:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 216)) {
-          _Internal::set_has_proxy_port(&has_bits);
+          _Internal::set_has_proxy_port(&_has_bits_);
           proxy_port_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
@@ -1168,8 +1189,27 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
       // optional uint32 thread_pool_size = 31 [default = 64];
       case 31:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 248)) {
-          _Internal::set_has_thread_pool_size(&has_bits);
+          _Internal::set_has_thread_pool_size(&_has_bits_);
           thread_pool_size_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // optional string sts_endpoint = 32 [default = ""];
+      case 32:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 2)) {
+          auto str = _internal_mutable_sts_endpoint();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          #ifndef NDEBUG
+          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "aws.kinesis.protobuf.Configuration.sts_endpoint");
+          #endif  // !NDEBUG
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // optional uint64 sts_port = 33 [default = 443];
+      case 33:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          _Internal::set_has_sts_port(&_has_bits_);
+          sts_port_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -1198,7 +1238,6 @@ const char* Configuration::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_
     }  // switch
   }  // while
 success:
-  _has_bits_.Or(has_bits);
   return ptr;
 failure:
   ptr = nullptr;
@@ -1214,19 +1253,19 @@ failure:
 
   cached_has_bits = _has_bits_[0];
   // optional bool aggregation_enabled = 1 [default = true];
-  if (cached_has_bits & 0x00800000u) {
+  if (cached_has_bits & 0x01000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(1, this->_internal_aggregation_enabled(), target);
   }
 
   // optional uint64 aggregation_max_count = 2 [default = 4294967295];
-  if (cached_has_bits & 0x00002000u) {
+  if (cached_has_bits & 0x00004000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(2, this->_internal_aggregation_max_count(), target);
   }
 
   // optional uint64 aggregation_max_size = 3 [default = 51200];
-  if (cached_has_bits & 0x00004000u) {
+  if (cached_has_bits & 0x00008000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(3, this->_internal_aggregation_max_size(), target);
   }
@@ -1242,37 +1281,37 @@ failure:
   }
 
   // optional uint64 cloudwatch_port = 5 [default = 443];
-  if (cached_has_bits & 0x00008000u) {
+  if (cached_has_bits & 0x00010000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(5, this->_internal_cloudwatch_port(), target);
   }
 
   // optional uint64 collection_max_count = 6 [default = 500];
-  if (cached_has_bits & 0x00010000u) {
+  if (cached_has_bits & 0x00020000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(6, this->_internal_collection_max_count(), target);
   }
 
   // optional uint64 collection_max_size = 7 [default = 5242880];
-  if (cached_has_bits & 0x00020000u) {
+  if (cached_has_bits & 0x00040000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(7, this->_internal_collection_max_size(), target);
   }
 
   // optional uint64 connect_timeout = 8 [default = 6000];
-  if (cached_has_bits & 0x00040000u) {
+  if (cached_has_bits & 0x00080000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(8, this->_internal_connect_timeout(), target);
   }
 
   // optional bool enable_core_dumps = 9 [default = false];
-  if (cached_has_bits & 0x00000400u) {
+  if (cached_has_bits & 0x00000800u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(9, this->_internal_enable_core_dumps(), target);
   }
 
   // optional bool fail_if_throttled = 10 [default = false];
-  if (cached_has_bits & 0x00000800u) {
+  if (cached_has_bits & 0x00001000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(10, this->_internal_fail_if_throttled(), target);
   }
@@ -1288,7 +1327,7 @@ failure:
   }
 
   // optional uint64 kinesis_port = 12 [default = 443];
-  if (cached_has_bits & 0x00080000u) {
+  if (cached_has_bits & 0x00100000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(12, this->_internal_kinesis_port(), target);
   }
@@ -1304,7 +1343,7 @@ failure:
   }
 
   // optional uint64 max_connections = 14 [default = 24];
-  if (cached_has_bits & 0x00100000u) {
+  if (cached_has_bits & 0x00200000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(14, this->_internal_max_connections(), target);
   }
@@ -1340,31 +1379,31 @@ failure:
   }
 
   // optional uint64 metrics_upload_delay = 18 [default = 60000];
-  if (cached_has_bits & 0x00200000u) {
+  if (cached_has_bits & 0x00400000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(18, this->_internal_metrics_upload_delay(), target);
   }
 
   // optional uint64 min_connections = 19 [default = 1];
-  if (cached_has_bits & 0x00400000u) {
+  if (cached_has_bits & 0x00800000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(19, this->_internal_min_connections(), target);
   }
 
   // optional uint64 rate_limit = 20 [default = 150];
-  if (cached_has_bits & 0x04000000u) {
+  if (cached_has_bits & 0x08000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(20, this->_internal_rate_limit(), target);
   }
 
   // optional uint64 record_max_buffered_time = 21 [default = 100];
-  if (cached_has_bits & 0x08000000u) {
+  if (cached_has_bits & 0x10000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(21, this->_internal_record_max_buffered_time(), target);
   }
 
   // optional uint64 record_ttl = 22 [default = 30000];
-  if (cached_has_bits & 0x10000000u) {
+  if (cached_has_bits & 0x20000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(22, this->_internal_record_ttl(), target);
   }
@@ -1380,13 +1419,13 @@ failure:
   }
 
   // optional uint64 request_timeout = 24 [default = 6000];
-  if (cached_has_bits & 0x20000000u) {
+  if (cached_has_bits & 0x40000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(24, this->_internal_request_timeout(), target);
   }
 
   // optional bool verify_certificate = 25 [default = true];
-  if (cached_has_bits & 0x01000000u) {
+  if (cached_has_bits & 0x02000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(25, this->_internal_verify_certificate(), target);
   }
@@ -1402,7 +1441,7 @@ failure:
   }
 
   // optional uint64 proxy_port = 27 [default = 443];
-  if (cached_has_bits & 0x40000000u) {
+  if (cached_has_bits & 0x80000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(27, this->_internal_proxy_port(), target);
   }
@@ -1428,16 +1467,33 @@ failure:
   }
 
   // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];
-  if (cached_has_bits & 0x00001000u) {
+  if (cached_has_bits & 0x00002000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteEnumToArray(
       30, this->_internal_thread_config(), target);
   }
 
   // optional uint32 thread_pool_size = 31 [default = 64];
-  if (cached_has_bits & 0x02000000u) {
+  if (cached_has_bits & 0x04000000u) {
     target = stream->EnsureSpace(target);
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(31, this->_internal_thread_pool_size(), target);
+  }
+
+  // optional string sts_endpoint = 32 [default = ""];
+  if (cached_has_bits & 0x00000400u) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
+      this->_internal_sts_endpoint().data(), static_cast<int>(this->_internal_sts_endpoint().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
+      "aws.kinesis.protobuf.Configuration.sts_endpoint");
+    target = stream->WriteStringMaybeAliased(
+        32, this->_internal_sts_endpoint(), target);
+  }
+
+  cached_has_bits = _has_bits_[1];
+  // optional uint64 sts_port = 33 [default = 443];
+  if (cached_has_bits & 0x00000001u) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt64ToArray(33, this->_internal_sts_port(), target);
   }
 
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
@@ -1545,149 +1601,164 @@ size_t Configuration::ByteSizeLong() const {
           this->_internal_proxy_password());
     }
 
-    // optional bool enable_core_dumps = 9 [default = false];
+    // optional string sts_endpoint = 32 [default = ""];
     if (cached_has_bits & 0x00000400u) {
-      total_size += 1 + 1;
+      total_size += 2 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+          this->_internal_sts_endpoint());
     }
 
-    // optional bool fail_if_throttled = 10 [default = false];
+    // optional bool enable_core_dumps = 9 [default = false];
     if (cached_has_bits & 0x00000800u) {
       total_size += 1 + 1;
     }
 
-    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];
+    // optional bool fail_if_throttled = 10 [default = false];
     if (cached_has_bits & 0x00001000u) {
+      total_size += 1 + 1;
+    }
+
+    // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];
+    if (cached_has_bits & 0x00002000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::EnumSize(this->_internal_thread_config());
     }
 
     // optional uint64 aggregation_max_count = 2 [default = 4294967295];
-    if (cached_has_bits & 0x00002000u) {
+    if (cached_has_bits & 0x00004000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_aggregation_max_count());
     }
 
     // optional uint64 aggregation_max_size = 3 [default = 51200];
-    if (cached_has_bits & 0x00004000u) {
+    if (cached_has_bits & 0x00008000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_aggregation_max_size());
     }
 
+  }
+  if (cached_has_bits & 0x00ff0000u) {
     // optional uint64 cloudwatch_port = 5 [default = 443];
-    if (cached_has_bits & 0x00008000u) {
+    if (cached_has_bits & 0x00010000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_cloudwatch_port());
     }
 
-  }
-  if (cached_has_bits & 0x00ff0000u) {
     // optional uint64 collection_max_count = 6 [default = 500];
-    if (cached_has_bits & 0x00010000u) {
+    if (cached_has_bits & 0x00020000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_collection_max_count());
     }
 
     // optional uint64 collection_max_size = 7 [default = 5242880];
-    if (cached_has_bits & 0x00020000u) {
+    if (cached_has_bits & 0x00040000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_collection_max_size());
     }
 
     // optional uint64 connect_timeout = 8 [default = 6000];
-    if (cached_has_bits & 0x00040000u) {
+    if (cached_has_bits & 0x00080000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_connect_timeout());
     }
 
     // optional uint64 kinesis_port = 12 [default = 443];
-    if (cached_has_bits & 0x00080000u) {
+    if (cached_has_bits & 0x00100000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_kinesis_port());
     }
 
     // optional uint64 max_connections = 14 [default = 24];
-    if (cached_has_bits & 0x00100000u) {
+    if (cached_has_bits & 0x00200000u) {
       total_size += 1 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_max_connections());
     }
 
     // optional uint64 metrics_upload_delay = 18 [default = 60000];
-    if (cached_has_bits & 0x00200000u) {
+    if (cached_has_bits & 0x00400000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_metrics_upload_delay());
     }
 
     // optional uint64 min_connections = 19 [default = 1];
-    if (cached_has_bits & 0x00400000u) {
+    if (cached_has_bits & 0x00800000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_min_connections());
     }
 
+  }
+  if (cached_has_bits & 0xff000000u) {
     // optional bool aggregation_enabled = 1 [default = true];
-    if (cached_has_bits & 0x00800000u) {
+    if (cached_has_bits & 0x01000000u) {
       total_size += 1 + 1;
     }
 
-  }
-  if (cached_has_bits & 0x7f000000u) {
     // optional bool verify_certificate = 25 [default = true];
-    if (cached_has_bits & 0x01000000u) {
+    if (cached_has_bits & 0x02000000u) {
       total_size += 2 + 1;
     }
 
     // optional uint32 thread_pool_size = 31 [default = 64];
-    if (cached_has_bits & 0x02000000u) {
+    if (cached_has_bits & 0x04000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt32Size(
           this->_internal_thread_pool_size());
     }
 
     // optional uint64 rate_limit = 20 [default = 150];
-    if (cached_has_bits & 0x04000000u) {
+    if (cached_has_bits & 0x08000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_rate_limit());
     }
 
     // optional uint64 record_max_buffered_time = 21 [default = 100];
-    if (cached_has_bits & 0x08000000u) {
+    if (cached_has_bits & 0x10000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_record_max_buffered_time());
     }
 
     // optional uint64 record_ttl = 22 [default = 30000];
-    if (cached_has_bits & 0x10000000u) {
+    if (cached_has_bits & 0x20000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_record_ttl());
     }
 
     // optional uint64 request_timeout = 24 [default = 6000];
-    if (cached_has_bits & 0x20000000u) {
+    if (cached_has_bits & 0x40000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_request_timeout());
     }
 
     // optional uint64 proxy_port = 27 [default = 443];
-    if (cached_has_bits & 0x40000000u) {
+    if (cached_has_bits & 0x80000000u) {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
           this->_internal_proxy_port());
     }
 
   }
+  // optional uint64 sts_port = 33 [default = 443];
+  cached_has_bits = _has_bits_[1];
+  if (cached_has_bits & 0x00000001u) {
+    total_size += 2 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt64Size(
+        this->_internal_sts_port());
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
         _internal_metadata_, total_size, &_cached_size_);
@@ -1765,75 +1836,82 @@ void Configuration::MergeFrom(const Configuration& from) {
       proxy_password_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.proxy_password_);
     }
     if (cached_has_bits & 0x00000400u) {
-      enable_core_dumps_ = from.enable_core_dumps_;
+      _has_bits_[0] |= 0x00000400u;
+      sts_endpoint_.AssignWithDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from.sts_endpoint_);
     }
     if (cached_has_bits & 0x00000800u) {
-      fail_if_throttled_ = from.fail_if_throttled_;
+      enable_core_dumps_ = from.enable_core_dumps_;
     }
     if (cached_has_bits & 0x00001000u) {
-      thread_config_ = from.thread_config_;
+      fail_if_throttled_ = from.fail_if_throttled_;
     }
     if (cached_has_bits & 0x00002000u) {
-      aggregation_max_count_ = from.aggregation_max_count_;
+      thread_config_ = from.thread_config_;
     }
     if (cached_has_bits & 0x00004000u) {
-      aggregation_max_size_ = from.aggregation_max_size_;
+      aggregation_max_count_ = from.aggregation_max_count_;
     }
     if (cached_has_bits & 0x00008000u) {
-      cloudwatch_port_ = from.cloudwatch_port_;
+      aggregation_max_size_ = from.aggregation_max_size_;
     }
     _has_bits_[0] |= cached_has_bits;
   }
   if (cached_has_bits & 0x00ff0000u) {
     if (cached_has_bits & 0x00010000u) {
-      collection_max_count_ = from.collection_max_count_;
+      cloudwatch_port_ = from.cloudwatch_port_;
     }
     if (cached_has_bits & 0x00020000u) {
-      collection_max_size_ = from.collection_max_size_;
+      collection_max_count_ = from.collection_max_count_;
     }
     if (cached_has_bits & 0x00040000u) {
-      connect_timeout_ = from.connect_timeout_;
+      collection_max_size_ = from.collection_max_size_;
     }
     if (cached_has_bits & 0x00080000u) {
-      kinesis_port_ = from.kinesis_port_;
+      connect_timeout_ = from.connect_timeout_;
     }
     if (cached_has_bits & 0x00100000u) {
-      max_connections_ = from.max_connections_;
+      kinesis_port_ = from.kinesis_port_;
     }
     if (cached_has_bits & 0x00200000u) {
-      metrics_upload_delay_ = from.metrics_upload_delay_;
+      max_connections_ = from.max_connections_;
     }
     if (cached_has_bits & 0x00400000u) {
-      min_connections_ = from.min_connections_;
+      metrics_upload_delay_ = from.metrics_upload_delay_;
     }
     if (cached_has_bits & 0x00800000u) {
-      aggregation_enabled_ = from.aggregation_enabled_;
+      min_connections_ = from.min_connections_;
     }
     _has_bits_[0] |= cached_has_bits;
   }
-  if (cached_has_bits & 0x7f000000u) {
+  if (cached_has_bits & 0xff000000u) {
     if (cached_has_bits & 0x01000000u) {
-      verify_certificate_ = from.verify_certificate_;
+      aggregation_enabled_ = from.aggregation_enabled_;
     }
     if (cached_has_bits & 0x02000000u) {
-      thread_pool_size_ = from.thread_pool_size_;
+      verify_certificate_ = from.verify_certificate_;
     }
     if (cached_has_bits & 0x04000000u) {
-      rate_limit_ = from.rate_limit_;
+      thread_pool_size_ = from.thread_pool_size_;
     }
     if (cached_has_bits & 0x08000000u) {
-      record_max_buffered_time_ = from.record_max_buffered_time_;
+      rate_limit_ = from.rate_limit_;
     }
     if (cached_has_bits & 0x10000000u) {
-      record_ttl_ = from.record_ttl_;
+      record_max_buffered_time_ = from.record_max_buffered_time_;
     }
     if (cached_has_bits & 0x20000000u) {
-      request_timeout_ = from.request_timeout_;
+      record_ttl_ = from.record_ttl_;
     }
     if (cached_has_bits & 0x40000000u) {
+      request_timeout_ = from.request_timeout_;
+    }
+    if (cached_has_bits & 0x80000000u) {
       proxy_port_ = from.proxy_port_;
     }
     _has_bits_[0] |= cached_has_bits;
+  }
+  if (from._internal_has_sts_port()) {
+    _internal_set_sts_port(from._internal_sts_port());
   }
 }
 
@@ -1860,6 +1938,7 @@ void Configuration::InternalSwap(Configuration* other) {
   using std::swap;
   _internal_metadata_.Swap(&other->_internal_metadata_);
   swap(_has_bits_[0], other->_has_bits_[0]);
+  swap(_has_bits_[1], other->_has_bits_[1]);
   additional_metric_dims_.InternalSwap(&other->additional_metric_dims_);
   cloudwatch_endpoint_.Swap(&other->cloudwatch_endpoint_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
@@ -1880,6 +1959,8 @@ void Configuration::InternalSwap(Configuration* other) {
   proxy_user_name_.Swap(&other->proxy_user_name_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   proxy_password_.Swap(&other->proxy_password_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  sts_endpoint_.Swap(&other->sts_endpoint_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   swap(enable_core_dumps_, other->enable_core_dumps_);
   swap(fail_if_throttled_, other->fail_if_throttled_);
@@ -1902,6 +1983,7 @@ void Configuration::InternalSwap(Configuration* other) {
   swap(record_ttl_, other->record_ttl_);
   swap(request_timeout_, other->request_timeout_);
   swap(proxy_port_, other->proxy_port_);
+  swap(sts_port_, other->sts_port_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata Configuration::GetMetadata() const {

--- a/aws/kinesis/protobuf/config.pb.h
+++ b/aws/kinesis/protobuf/config.pb.h
@@ -448,6 +448,7 @@ class Configuration :
     kProxyHostFieldNumber = 26,
     kProxyUserNameFieldNumber = 28,
     kProxyPasswordFieldNumber = 29,
+    kStsEndpointFieldNumber = 32,
     kEnableCoreDumpsFieldNumber = 9,
     kFailIfThrottledFieldNumber = 10,
     kThreadConfigFieldNumber = 30,
@@ -469,6 +470,7 @@ class Configuration :
     kRecordTtlFieldNumber = 22,
     kRequestTimeoutFieldNumber = 24,
     kProxyPortFieldNumber = 27,
+    kStsPortFieldNumber = 33,
   };
   // repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;
   int additional_metric_dims_size() const;
@@ -686,6 +688,26 @@ class Configuration :
   const std::string& _internal_proxy_password() const;
   void _internal_set_proxy_password(const std::string& value);
   std::string* _internal_mutable_proxy_password();
+  public:
+
+  // optional string sts_endpoint = 32 [default = ""];
+  bool has_sts_endpoint() const;
+  private:
+  bool _internal_has_sts_endpoint() const;
+  public:
+  void clear_sts_endpoint();
+  const std::string& sts_endpoint() const;
+  void set_sts_endpoint(const std::string& value);
+  void set_sts_endpoint(std::string&& value);
+  void set_sts_endpoint(const char* value);
+  void set_sts_endpoint(const char* value, size_t size);
+  std::string* mutable_sts_endpoint();
+  std::string* release_sts_endpoint();
+  void set_allocated_sts_endpoint(std::string* sts_endpoint);
+  private:
+  const std::string& _internal_sts_endpoint() const;
+  void _internal_set_sts_endpoint(const std::string& value);
+  std::string* _internal_mutable_sts_endpoint();
   public:
 
   // optional bool enable_core_dumps = 9 [default = false];
@@ -961,12 +983,25 @@ class Configuration :
   void _internal_set_proxy_port(::PROTOBUF_NAMESPACE_ID::uint64 value);
   public:
 
+  // optional uint64 sts_port = 33 [default = 443];
+  bool has_sts_port() const;
+  private:
+  bool _internal_has_sts_port() const;
+  public:
+  void clear_sts_port();
+  ::PROTOBUF_NAMESPACE_ID::uint64 sts_port() const;
+  void set_sts_port(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::uint64 _internal_sts_port() const;
+  void _internal_set_sts_port(::PROTOBUF_NAMESPACE_ID::uint64 value);
+  public:
+
   // @@protoc_insertion_point(class_scope:aws.kinesis.protobuf.Configuration)
  private:
   class _Internal;
 
   ::PROTOBUF_NAMESPACE_ID::internal::InternalMetadataWithArena _internal_metadata_;
-  ::PROTOBUF_NAMESPACE_ID::internal::HasBits<1> _has_bits_;
+  ::PROTOBUF_NAMESPACE_ID::internal::HasBits<2> _has_bits_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::aws::kinesis::protobuf::AdditionalDimension > additional_metric_dims_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr cloudwatch_endpoint_;
@@ -991,6 +1026,7 @@ class Configuration :
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr proxy_host_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr proxy_user_name_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr proxy_password_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr sts_endpoint_;
   bool enable_core_dumps_;
   bool fail_if_throttled_;
   int thread_config_;
@@ -1012,6 +1048,7 @@ class Configuration :
   ::PROTOBUF_NAMESPACE_ID::uint64 record_ttl_;
   ::PROTOBUF_NAMESPACE_ID::uint64 request_timeout_;
   ::PROTOBUF_NAMESPACE_ID::uint64 proxy_port_;
+  ::PROTOBUF_NAMESPACE_ID::uint64 sts_port_;
   friend struct ::TableStruct_config_2eproto;
 };
 // ===================================================================
@@ -1283,7 +1320,7 @@ Configuration::additional_metric_dims() const {
 
 // optional bool aggregation_enabled = 1 [default = true];
 inline bool Configuration::_internal_has_aggregation_enabled() const {
-  bool value = (_has_bits_[0] & 0x00800000u) != 0;
+  bool value = (_has_bits_[0] & 0x01000000u) != 0;
   return value;
 }
 inline bool Configuration::has_aggregation_enabled() const {
@@ -1291,7 +1328,7 @@ inline bool Configuration::has_aggregation_enabled() const {
 }
 inline void Configuration::clear_aggregation_enabled() {
   aggregation_enabled_ = true;
-  _has_bits_[0] &= ~0x00800000u;
+  _has_bits_[0] &= ~0x01000000u;
 }
 inline bool Configuration::_internal_aggregation_enabled() const {
   return aggregation_enabled_;
@@ -1301,7 +1338,7 @@ inline bool Configuration::aggregation_enabled() const {
   return _internal_aggregation_enabled();
 }
 inline void Configuration::_internal_set_aggregation_enabled(bool value) {
-  _has_bits_[0] |= 0x00800000u;
+  _has_bits_[0] |= 0x01000000u;
   aggregation_enabled_ = value;
 }
 inline void Configuration::set_aggregation_enabled(bool value) {
@@ -1311,7 +1348,7 @@ inline void Configuration::set_aggregation_enabled(bool value) {
 
 // optional uint64 aggregation_max_count = 2 [default = 4294967295];
 inline bool Configuration::_internal_has_aggregation_max_count() const {
-  bool value = (_has_bits_[0] & 0x00002000u) != 0;
+  bool value = (_has_bits_[0] & 0x00004000u) != 0;
   return value;
 }
 inline bool Configuration::has_aggregation_max_count() const {
@@ -1319,7 +1356,7 @@ inline bool Configuration::has_aggregation_max_count() const {
 }
 inline void Configuration::clear_aggregation_max_count() {
   aggregation_max_count_ = PROTOBUF_ULONGLONG(4294967295);
-  _has_bits_[0] &= ~0x00002000u;
+  _has_bits_[0] &= ~0x00004000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_aggregation_max_count() const {
   return aggregation_max_count_;
@@ -1329,7 +1366,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::aggregation_max_count() co
   return _internal_aggregation_max_count();
 }
 inline void Configuration::_internal_set_aggregation_max_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00002000u;
+  _has_bits_[0] |= 0x00004000u;
   aggregation_max_count_ = value;
 }
 inline void Configuration::set_aggregation_max_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1339,7 +1376,7 @@ inline void Configuration::set_aggregation_max_count(::PROTOBUF_NAMESPACE_ID::ui
 
 // optional uint64 aggregation_max_size = 3 [default = 51200];
 inline bool Configuration::_internal_has_aggregation_max_size() const {
-  bool value = (_has_bits_[0] & 0x00004000u) != 0;
+  bool value = (_has_bits_[0] & 0x00008000u) != 0;
   return value;
 }
 inline bool Configuration::has_aggregation_max_size() const {
@@ -1347,7 +1384,7 @@ inline bool Configuration::has_aggregation_max_size() const {
 }
 inline void Configuration::clear_aggregation_max_size() {
   aggregation_max_size_ = PROTOBUF_ULONGLONG(51200);
-  _has_bits_[0] &= ~0x00004000u;
+  _has_bits_[0] &= ~0x00008000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_aggregation_max_size() const {
   return aggregation_max_size_;
@@ -1357,7 +1394,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::aggregation_max_size() con
   return _internal_aggregation_max_size();
 }
 inline void Configuration::_internal_set_aggregation_max_size(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00004000u;
+  _has_bits_[0] |= 0x00008000u;
   aggregation_max_size_ = value;
 }
 inline void Configuration::set_aggregation_max_size(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1438,7 +1475,7 @@ inline void Configuration::set_allocated_cloudwatch_endpoint(std::string* cloudw
 
 // optional uint64 cloudwatch_port = 5 [default = 443];
 inline bool Configuration::_internal_has_cloudwatch_port() const {
-  bool value = (_has_bits_[0] & 0x00008000u) != 0;
+  bool value = (_has_bits_[0] & 0x00010000u) != 0;
   return value;
 }
 inline bool Configuration::has_cloudwatch_port() const {
@@ -1446,7 +1483,7 @@ inline bool Configuration::has_cloudwatch_port() const {
 }
 inline void Configuration::clear_cloudwatch_port() {
   cloudwatch_port_ = PROTOBUF_ULONGLONG(443);
-  _has_bits_[0] &= ~0x00008000u;
+  _has_bits_[0] &= ~0x00010000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_cloudwatch_port() const {
   return cloudwatch_port_;
@@ -1456,7 +1493,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::cloudwatch_port() const {
   return _internal_cloudwatch_port();
 }
 inline void Configuration::_internal_set_cloudwatch_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00008000u;
+  _has_bits_[0] |= 0x00010000u;
   cloudwatch_port_ = value;
 }
 inline void Configuration::set_cloudwatch_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1466,7 +1503,7 @@ inline void Configuration::set_cloudwatch_port(::PROTOBUF_NAMESPACE_ID::uint64 v
 
 // optional uint64 collection_max_count = 6 [default = 500];
 inline bool Configuration::_internal_has_collection_max_count() const {
-  bool value = (_has_bits_[0] & 0x00010000u) != 0;
+  bool value = (_has_bits_[0] & 0x00020000u) != 0;
   return value;
 }
 inline bool Configuration::has_collection_max_count() const {
@@ -1474,7 +1511,7 @@ inline bool Configuration::has_collection_max_count() const {
 }
 inline void Configuration::clear_collection_max_count() {
   collection_max_count_ = PROTOBUF_ULONGLONG(500);
-  _has_bits_[0] &= ~0x00010000u;
+  _has_bits_[0] &= ~0x00020000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_collection_max_count() const {
   return collection_max_count_;
@@ -1484,7 +1521,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::collection_max_count() con
   return _internal_collection_max_count();
 }
 inline void Configuration::_internal_set_collection_max_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00010000u;
+  _has_bits_[0] |= 0x00020000u;
   collection_max_count_ = value;
 }
 inline void Configuration::set_collection_max_count(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1494,7 +1531,7 @@ inline void Configuration::set_collection_max_count(::PROTOBUF_NAMESPACE_ID::uin
 
 // optional uint64 collection_max_size = 7 [default = 5242880];
 inline bool Configuration::_internal_has_collection_max_size() const {
-  bool value = (_has_bits_[0] & 0x00020000u) != 0;
+  bool value = (_has_bits_[0] & 0x00040000u) != 0;
   return value;
 }
 inline bool Configuration::has_collection_max_size() const {
@@ -1502,7 +1539,7 @@ inline bool Configuration::has_collection_max_size() const {
 }
 inline void Configuration::clear_collection_max_size() {
   collection_max_size_ = PROTOBUF_ULONGLONG(5242880);
-  _has_bits_[0] &= ~0x00020000u;
+  _has_bits_[0] &= ~0x00040000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_collection_max_size() const {
   return collection_max_size_;
@@ -1512,7 +1549,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::collection_max_size() cons
   return _internal_collection_max_size();
 }
 inline void Configuration::_internal_set_collection_max_size(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00020000u;
+  _has_bits_[0] |= 0x00040000u;
   collection_max_size_ = value;
 }
 inline void Configuration::set_collection_max_size(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1522,7 +1559,7 @@ inline void Configuration::set_collection_max_size(::PROTOBUF_NAMESPACE_ID::uint
 
 // optional uint64 connect_timeout = 8 [default = 6000];
 inline bool Configuration::_internal_has_connect_timeout() const {
-  bool value = (_has_bits_[0] & 0x00040000u) != 0;
+  bool value = (_has_bits_[0] & 0x00080000u) != 0;
   return value;
 }
 inline bool Configuration::has_connect_timeout() const {
@@ -1530,7 +1567,7 @@ inline bool Configuration::has_connect_timeout() const {
 }
 inline void Configuration::clear_connect_timeout() {
   connect_timeout_ = PROTOBUF_ULONGLONG(6000);
-  _has_bits_[0] &= ~0x00040000u;
+  _has_bits_[0] &= ~0x00080000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_connect_timeout() const {
   return connect_timeout_;
@@ -1540,7 +1577,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::connect_timeout() const {
   return _internal_connect_timeout();
 }
 inline void Configuration::_internal_set_connect_timeout(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00040000u;
+  _has_bits_[0] |= 0x00080000u;
   connect_timeout_ = value;
 }
 inline void Configuration::set_connect_timeout(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1550,7 +1587,7 @@ inline void Configuration::set_connect_timeout(::PROTOBUF_NAMESPACE_ID::uint64 v
 
 // optional bool enable_core_dumps = 9 [default = false];
 inline bool Configuration::_internal_has_enable_core_dumps() const {
-  bool value = (_has_bits_[0] & 0x00000400u) != 0;
+  bool value = (_has_bits_[0] & 0x00000800u) != 0;
   return value;
 }
 inline bool Configuration::has_enable_core_dumps() const {
@@ -1558,7 +1595,7 @@ inline bool Configuration::has_enable_core_dumps() const {
 }
 inline void Configuration::clear_enable_core_dumps() {
   enable_core_dumps_ = false;
-  _has_bits_[0] &= ~0x00000400u;
+  _has_bits_[0] &= ~0x00000800u;
 }
 inline bool Configuration::_internal_enable_core_dumps() const {
   return enable_core_dumps_;
@@ -1568,7 +1605,7 @@ inline bool Configuration::enable_core_dumps() const {
   return _internal_enable_core_dumps();
 }
 inline void Configuration::_internal_set_enable_core_dumps(bool value) {
-  _has_bits_[0] |= 0x00000400u;
+  _has_bits_[0] |= 0x00000800u;
   enable_core_dumps_ = value;
 }
 inline void Configuration::set_enable_core_dumps(bool value) {
@@ -1578,7 +1615,7 @@ inline void Configuration::set_enable_core_dumps(bool value) {
 
 // optional bool fail_if_throttled = 10 [default = false];
 inline bool Configuration::_internal_has_fail_if_throttled() const {
-  bool value = (_has_bits_[0] & 0x00000800u) != 0;
+  bool value = (_has_bits_[0] & 0x00001000u) != 0;
   return value;
 }
 inline bool Configuration::has_fail_if_throttled() const {
@@ -1586,7 +1623,7 @@ inline bool Configuration::has_fail_if_throttled() const {
 }
 inline void Configuration::clear_fail_if_throttled() {
   fail_if_throttled_ = false;
-  _has_bits_[0] &= ~0x00000800u;
+  _has_bits_[0] &= ~0x00001000u;
 }
 inline bool Configuration::_internal_fail_if_throttled() const {
   return fail_if_throttled_;
@@ -1596,7 +1633,7 @@ inline bool Configuration::fail_if_throttled() const {
   return _internal_fail_if_throttled();
 }
 inline void Configuration::_internal_set_fail_if_throttled(bool value) {
-  _has_bits_[0] |= 0x00000800u;
+  _has_bits_[0] |= 0x00001000u;
   fail_if_throttled_ = value;
 }
 inline void Configuration::set_fail_if_throttled(bool value) {
@@ -1677,7 +1714,7 @@ inline void Configuration::set_allocated_kinesis_endpoint(std::string* kinesis_e
 
 // optional uint64 kinesis_port = 12 [default = 443];
 inline bool Configuration::_internal_has_kinesis_port() const {
-  bool value = (_has_bits_[0] & 0x00080000u) != 0;
+  bool value = (_has_bits_[0] & 0x00100000u) != 0;
   return value;
 }
 inline bool Configuration::has_kinesis_port() const {
@@ -1685,7 +1722,7 @@ inline bool Configuration::has_kinesis_port() const {
 }
 inline void Configuration::clear_kinesis_port() {
   kinesis_port_ = PROTOBUF_ULONGLONG(443);
-  _has_bits_[0] &= ~0x00080000u;
+  _has_bits_[0] &= ~0x00100000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_kinesis_port() const {
   return kinesis_port_;
@@ -1695,7 +1732,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::kinesis_port() const {
   return _internal_kinesis_port();
 }
 inline void Configuration::_internal_set_kinesis_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00080000u;
+  _has_bits_[0] |= 0x00100000u;
   kinesis_port_ = value;
 }
 inline void Configuration::set_kinesis_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -1776,7 +1813,7 @@ inline void Configuration::set_allocated_log_level(std::string* log_level) {
 
 // optional uint64 max_connections = 14 [default = 24];
 inline bool Configuration::_internal_has_max_connections() const {
-  bool value = (_has_bits_[0] & 0x00100000u) != 0;
+  bool value = (_has_bits_[0] & 0x00200000u) != 0;
   return value;
 }
 inline bool Configuration::has_max_connections() const {
@@ -1784,7 +1821,7 @@ inline bool Configuration::has_max_connections() const {
 }
 inline void Configuration::clear_max_connections() {
   max_connections_ = PROTOBUF_ULONGLONG(24);
-  _has_bits_[0] &= ~0x00100000u;
+  _has_bits_[0] &= ~0x00200000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_max_connections() const {
   return max_connections_;
@@ -1794,7 +1831,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::max_connections() const {
   return _internal_max_connections();
 }
 inline void Configuration::_internal_set_max_connections(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00100000u;
+  _has_bits_[0] |= 0x00200000u;
   max_connections_ = value;
 }
 inline void Configuration::set_max_connections(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2017,7 +2054,7 @@ inline void Configuration::set_allocated_metrics_namespace(std::string* metrics_
 
 // optional uint64 metrics_upload_delay = 18 [default = 60000];
 inline bool Configuration::_internal_has_metrics_upload_delay() const {
-  bool value = (_has_bits_[0] & 0x00200000u) != 0;
+  bool value = (_has_bits_[0] & 0x00400000u) != 0;
   return value;
 }
 inline bool Configuration::has_metrics_upload_delay() const {
@@ -2025,7 +2062,7 @@ inline bool Configuration::has_metrics_upload_delay() const {
 }
 inline void Configuration::clear_metrics_upload_delay() {
   metrics_upload_delay_ = PROTOBUF_ULONGLONG(60000);
-  _has_bits_[0] &= ~0x00200000u;
+  _has_bits_[0] &= ~0x00400000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_metrics_upload_delay() const {
   return metrics_upload_delay_;
@@ -2035,7 +2072,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::metrics_upload_delay() con
   return _internal_metrics_upload_delay();
 }
 inline void Configuration::_internal_set_metrics_upload_delay(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00200000u;
+  _has_bits_[0] |= 0x00400000u;
   metrics_upload_delay_ = value;
 }
 inline void Configuration::set_metrics_upload_delay(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2045,7 +2082,7 @@ inline void Configuration::set_metrics_upload_delay(::PROTOBUF_NAMESPACE_ID::uin
 
 // optional uint64 min_connections = 19 [default = 1];
 inline bool Configuration::_internal_has_min_connections() const {
-  bool value = (_has_bits_[0] & 0x00400000u) != 0;
+  bool value = (_has_bits_[0] & 0x00800000u) != 0;
   return value;
 }
 inline bool Configuration::has_min_connections() const {
@@ -2053,7 +2090,7 @@ inline bool Configuration::has_min_connections() const {
 }
 inline void Configuration::clear_min_connections() {
   min_connections_ = PROTOBUF_ULONGLONG(1);
-  _has_bits_[0] &= ~0x00400000u;
+  _has_bits_[0] &= ~0x00800000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_min_connections() const {
   return min_connections_;
@@ -2063,7 +2100,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::min_connections() const {
   return _internal_min_connections();
 }
 inline void Configuration::_internal_set_min_connections(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x00400000u;
+  _has_bits_[0] |= 0x00800000u;
   min_connections_ = value;
 }
 inline void Configuration::set_min_connections(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2073,7 +2110,7 @@ inline void Configuration::set_min_connections(::PROTOBUF_NAMESPACE_ID::uint64 v
 
 // optional uint64 rate_limit = 20 [default = 150];
 inline bool Configuration::_internal_has_rate_limit() const {
-  bool value = (_has_bits_[0] & 0x04000000u) != 0;
+  bool value = (_has_bits_[0] & 0x08000000u) != 0;
   return value;
 }
 inline bool Configuration::has_rate_limit() const {
@@ -2081,7 +2118,7 @@ inline bool Configuration::has_rate_limit() const {
 }
 inline void Configuration::clear_rate_limit() {
   rate_limit_ = PROTOBUF_ULONGLONG(150);
-  _has_bits_[0] &= ~0x04000000u;
+  _has_bits_[0] &= ~0x08000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_rate_limit() const {
   return rate_limit_;
@@ -2091,7 +2128,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::rate_limit() const {
   return _internal_rate_limit();
 }
 inline void Configuration::_internal_set_rate_limit(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x04000000u;
+  _has_bits_[0] |= 0x08000000u;
   rate_limit_ = value;
 }
 inline void Configuration::set_rate_limit(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2101,7 +2138,7 @@ inline void Configuration::set_rate_limit(::PROTOBUF_NAMESPACE_ID::uint64 value)
 
 // optional uint64 record_max_buffered_time = 21 [default = 100];
 inline bool Configuration::_internal_has_record_max_buffered_time() const {
-  bool value = (_has_bits_[0] & 0x08000000u) != 0;
+  bool value = (_has_bits_[0] & 0x10000000u) != 0;
   return value;
 }
 inline bool Configuration::has_record_max_buffered_time() const {
@@ -2109,7 +2146,7 @@ inline bool Configuration::has_record_max_buffered_time() const {
 }
 inline void Configuration::clear_record_max_buffered_time() {
   record_max_buffered_time_ = PROTOBUF_ULONGLONG(100);
-  _has_bits_[0] &= ~0x08000000u;
+  _has_bits_[0] &= ~0x10000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_record_max_buffered_time() const {
   return record_max_buffered_time_;
@@ -2119,7 +2156,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::record_max_buffered_time()
   return _internal_record_max_buffered_time();
 }
 inline void Configuration::_internal_set_record_max_buffered_time(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x08000000u;
+  _has_bits_[0] |= 0x10000000u;
   record_max_buffered_time_ = value;
 }
 inline void Configuration::set_record_max_buffered_time(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2129,7 +2166,7 @@ inline void Configuration::set_record_max_buffered_time(::PROTOBUF_NAMESPACE_ID:
 
 // optional uint64 record_ttl = 22 [default = 30000];
 inline bool Configuration::_internal_has_record_ttl() const {
-  bool value = (_has_bits_[0] & 0x10000000u) != 0;
+  bool value = (_has_bits_[0] & 0x20000000u) != 0;
   return value;
 }
 inline bool Configuration::has_record_ttl() const {
@@ -2137,7 +2174,7 @@ inline bool Configuration::has_record_ttl() const {
 }
 inline void Configuration::clear_record_ttl() {
   record_ttl_ = PROTOBUF_ULONGLONG(30000);
-  _has_bits_[0] &= ~0x10000000u;
+  _has_bits_[0] &= ~0x20000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_record_ttl() const {
   return record_ttl_;
@@ -2147,7 +2184,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::record_ttl() const {
   return _internal_record_ttl();
 }
 inline void Configuration::_internal_set_record_ttl(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x10000000u;
+  _has_bits_[0] |= 0x20000000u;
   record_ttl_ = value;
 }
 inline void Configuration::set_record_ttl(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2228,7 +2265,7 @@ inline void Configuration::set_allocated_region(std::string* region) {
 
 // optional uint64 request_timeout = 24 [default = 6000];
 inline bool Configuration::_internal_has_request_timeout() const {
-  bool value = (_has_bits_[0] & 0x20000000u) != 0;
+  bool value = (_has_bits_[0] & 0x40000000u) != 0;
   return value;
 }
 inline bool Configuration::has_request_timeout() const {
@@ -2236,7 +2273,7 @@ inline bool Configuration::has_request_timeout() const {
 }
 inline void Configuration::clear_request_timeout() {
   request_timeout_ = PROTOBUF_ULONGLONG(6000);
-  _has_bits_[0] &= ~0x20000000u;
+  _has_bits_[0] &= ~0x40000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_request_timeout() const {
   return request_timeout_;
@@ -2246,7 +2283,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::request_timeout() const {
   return _internal_request_timeout();
 }
 inline void Configuration::_internal_set_request_timeout(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x20000000u;
+  _has_bits_[0] |= 0x40000000u;
   request_timeout_ = value;
 }
 inline void Configuration::set_request_timeout(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2256,7 +2293,7 @@ inline void Configuration::set_request_timeout(::PROTOBUF_NAMESPACE_ID::uint64 v
 
 // optional bool verify_certificate = 25 [default = true];
 inline bool Configuration::_internal_has_verify_certificate() const {
-  bool value = (_has_bits_[0] & 0x01000000u) != 0;
+  bool value = (_has_bits_[0] & 0x02000000u) != 0;
   return value;
 }
 inline bool Configuration::has_verify_certificate() const {
@@ -2264,7 +2301,7 @@ inline bool Configuration::has_verify_certificate() const {
 }
 inline void Configuration::clear_verify_certificate() {
   verify_certificate_ = true;
-  _has_bits_[0] &= ~0x01000000u;
+  _has_bits_[0] &= ~0x02000000u;
 }
 inline bool Configuration::_internal_verify_certificate() const {
   return verify_certificate_;
@@ -2274,7 +2311,7 @@ inline bool Configuration::verify_certificate() const {
   return _internal_verify_certificate();
 }
 inline void Configuration::_internal_set_verify_certificate(bool value) {
-  _has_bits_[0] |= 0x01000000u;
+  _has_bits_[0] |= 0x02000000u;
   verify_certificate_ = value;
 }
 inline void Configuration::set_verify_certificate(bool value) {
@@ -2355,7 +2392,7 @@ inline void Configuration::set_allocated_proxy_host(std::string* proxy_host) {
 
 // optional uint64 proxy_port = 27 [default = 443];
 inline bool Configuration::_internal_has_proxy_port() const {
-  bool value = (_has_bits_[0] & 0x40000000u) != 0;
+  bool value = (_has_bits_[0] & 0x80000000u) != 0;
   return value;
 }
 inline bool Configuration::has_proxy_port() const {
@@ -2363,7 +2400,7 @@ inline bool Configuration::has_proxy_port() const {
 }
 inline void Configuration::clear_proxy_port() {
   proxy_port_ = PROTOBUF_ULONGLONG(443);
-  _has_bits_[0] &= ~0x40000000u;
+  _has_bits_[0] &= ~0x80000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_proxy_port() const {
   return proxy_port_;
@@ -2373,7 +2410,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::proxy_port() const {
   return _internal_proxy_port();
 }
 inline void Configuration::_internal_set_proxy_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
-  _has_bits_[0] |= 0x40000000u;
+  _has_bits_[0] |= 0x80000000u;
   proxy_port_ = value;
 }
 inline void Configuration::set_proxy_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
@@ -2523,9 +2560,108 @@ inline void Configuration::set_allocated_proxy_password(std::string* proxy_passw
   // @@protoc_insertion_point(field_set_allocated:aws.kinesis.protobuf.Configuration.proxy_password)
 }
 
+// optional string sts_endpoint = 32 [default = ""];
+inline bool Configuration::_internal_has_sts_endpoint() const {
+  bool value = (_has_bits_[0] & 0x00000400u) != 0;
+  return value;
+}
+inline bool Configuration::has_sts_endpoint() const {
+  return _internal_has_sts_endpoint();
+}
+inline void Configuration::clear_sts_endpoint() {
+  sts_endpoint_.ClearToEmptyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  _has_bits_[0] &= ~0x00000400u;
+}
+inline const std::string& Configuration::sts_endpoint() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.sts_endpoint)
+  return _internal_sts_endpoint();
+}
+inline void Configuration::set_sts_endpoint(const std::string& value) {
+  _internal_set_sts_endpoint(value);
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.sts_endpoint)
+}
+inline std::string* Configuration::mutable_sts_endpoint() {
+  // @@protoc_insertion_point(field_mutable:aws.kinesis.protobuf.Configuration.sts_endpoint)
+  return _internal_mutable_sts_endpoint();
+}
+inline const std::string& Configuration::_internal_sts_endpoint() const {
+  return sts_endpoint_.GetNoArena();
+}
+inline void Configuration::_internal_set_sts_endpoint(const std::string& value) {
+  _has_bits_[0] |= 0x00000400u;
+  sts_endpoint_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value);
+}
+inline void Configuration::set_sts_endpoint(std::string&& value) {
+  _has_bits_[0] |= 0x00000400u;
+  sts_endpoint_.SetNoArena(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:aws.kinesis.protobuf.Configuration.sts_endpoint)
+}
+inline void Configuration::set_sts_endpoint(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _has_bits_[0] |= 0x00000400u;
+  sts_endpoint_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:aws.kinesis.protobuf.Configuration.sts_endpoint)
+}
+inline void Configuration::set_sts_endpoint(const char* value, size_t size) {
+  _has_bits_[0] |= 0x00000400u;
+  sts_endpoint_.SetNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:aws.kinesis.protobuf.Configuration.sts_endpoint)
+}
+inline std::string* Configuration::_internal_mutable_sts_endpoint() {
+  _has_bits_[0] |= 0x00000400u;
+  return sts_endpoint_.MutableNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+inline std::string* Configuration::release_sts_endpoint() {
+  // @@protoc_insertion_point(field_release:aws.kinesis.protobuf.Configuration.sts_endpoint)
+  if (!_internal_has_sts_endpoint()) {
+    return nullptr;
+  }
+  _has_bits_[0] &= ~0x00000400u;
+  return sts_endpoint_.ReleaseNonDefaultNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+inline void Configuration::set_allocated_sts_endpoint(std::string* sts_endpoint) {
+  if (sts_endpoint != nullptr) {
+    _has_bits_[0] |= 0x00000400u;
+  } else {
+    _has_bits_[0] &= ~0x00000400u;
+  }
+  sts_endpoint_.SetAllocatedNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), sts_endpoint);
+  // @@protoc_insertion_point(field_set_allocated:aws.kinesis.protobuf.Configuration.sts_endpoint)
+}
+
+// optional uint64 sts_port = 33 [default = 443];
+inline bool Configuration::_internal_has_sts_port() const {
+  bool value = (_has_bits_[1] & 0x00000001u) != 0;
+  return value;
+}
+inline bool Configuration::has_sts_port() const {
+  return _internal_has_sts_port();
+}
+inline void Configuration::clear_sts_port() {
+  sts_port_ = PROTOBUF_ULONGLONG(443);
+  _has_bits_[1] &= ~0x00000001u;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::_internal_sts_port() const {
+  return sts_port_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::uint64 Configuration::sts_port() const {
+  // @@protoc_insertion_point(field_get:aws.kinesis.protobuf.Configuration.sts_port)
+  return _internal_sts_port();
+}
+inline void Configuration::_internal_set_sts_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _has_bits_[1] |= 0x00000001u;
+  sts_port_ = value;
+}
+inline void Configuration::set_sts_port(::PROTOBUF_NAMESPACE_ID::uint64 value) {
+  _internal_set_sts_port(value);
+  // @@protoc_insertion_point(field_set:aws.kinesis.protobuf.Configuration.sts_port)
+}
+
 // optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];
 inline bool Configuration::_internal_has_thread_config() const {
-  bool value = (_has_bits_[0] & 0x00001000u) != 0;
+  bool value = (_has_bits_[0] & 0x00002000u) != 0;
   return value;
 }
 inline bool Configuration::has_thread_config() const {
@@ -2533,7 +2669,7 @@ inline bool Configuration::has_thread_config() const {
 }
 inline void Configuration::clear_thread_config() {
   thread_config_ = 0;
-  _has_bits_[0] &= ~0x00001000u;
+  _has_bits_[0] &= ~0x00002000u;
 }
 inline ::aws::kinesis::protobuf::Configuration_ThreadConfig Configuration::_internal_thread_config() const {
   return static_cast< ::aws::kinesis::protobuf::Configuration_ThreadConfig >(thread_config_);
@@ -2544,7 +2680,7 @@ inline ::aws::kinesis::protobuf::Configuration_ThreadConfig Configuration::threa
 }
 inline void Configuration::_internal_set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value) {
   assert(::aws::kinesis::protobuf::Configuration_ThreadConfig_IsValid(value));
-  _has_bits_[0] |= 0x00001000u;
+  _has_bits_[0] |= 0x00002000u;
   thread_config_ = value;
 }
 inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configuration_ThreadConfig value) {
@@ -2554,7 +2690,7 @@ inline void Configuration::set_thread_config(::aws::kinesis::protobuf::Configura
 
 // optional uint32 thread_pool_size = 31 [default = 64];
 inline bool Configuration::_internal_has_thread_pool_size() const {
-  bool value = (_has_bits_[0] & 0x02000000u) != 0;
+  bool value = (_has_bits_[0] & 0x04000000u) != 0;
   return value;
 }
 inline bool Configuration::has_thread_pool_size() const {
@@ -2562,7 +2698,7 @@ inline bool Configuration::has_thread_pool_size() const {
 }
 inline void Configuration::clear_thread_pool_size() {
   thread_pool_size_ = 64u;
-  _has_bits_[0] &= ~0x02000000u;
+  _has_bits_[0] &= ~0x04000000u;
 }
 inline ::PROTOBUF_NAMESPACE_ID::uint32 Configuration::_internal_thread_pool_size() const {
   return thread_pool_size_;
@@ -2572,7 +2708,7 @@ inline ::PROTOBUF_NAMESPACE_ID::uint32 Configuration::thread_pool_size() const {
   return _internal_thread_pool_size();
 }
 inline void Configuration::_internal_set_thread_pool_size(::PROTOBUF_NAMESPACE_ID::uint32 value) {
-  _has_bits_[0] |= 0x02000000u;
+  _has_bits_[0] |= 0x04000000u;
   thread_pool_size_ = value;
 }
 inline void Configuration::set_thread_pool_size(::PROTOBUF_NAMESPACE_ID::uint32 value) {

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -41,6 +41,8 @@ message Configuration {
   optional uint64 proxy_port = 27 [default = 443];
   optional string proxy_user_name = 28 [default = ""];
   optional string proxy_password = 29 [default = ""];
+  optional string sts_endpoint = 32 [default = ""];
+  optional uint64 sts_port = 33 [default = 443];
   enum ThreadConfig {
     PER_REQUEST = 0;
     POOLED = 1;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,7 +15,7 @@ silence() {
 OPENSSL_VERSION="1.1.1s"
 BOOST_VERSION="1.80.0"
 BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.80.0 to 1_80_0
-ZLIB_VERSION="1.2.12"
+ZLIB_VERSION="1.2.13"
 PROTOBUF_VERSION="3.11.4"
 CURL_VERSION="7.86.0"
 AWS_SDK_CPP_VERSION="1.10.32"
@@ -138,7 +138,7 @@ if [ ! -d "openssl-${OPENSSL_VERSION}" ]; then
       echo -e '\t$(COMPILE.c) $(OUTPUT_OPTION) $<;' >>$f
     done
   else
-    silence ./config "$OPTS" --prefix="$INSTALL_DIR"
+    silence ./config $OPTS --prefix="$INSTALL_DIR"
   fi
 
   silence make depend
@@ -271,7 +271,7 @@ fi
 cd ..
 
 # Build the native kinesis producer
-$CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" .
+$CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 make -j8
 
 #copy native producer to a location that the java producer can package it

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,19 +12,13 @@ silence() {
   fi
 }
 
-OPENSSL_VERSION="1.1.1q"
+OPENSSL_VERSION="1.1.1s"
 BOOST_VERSION="1.80.0"
 BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.80.0 to 1_80_0
 ZLIB_VERSION="1.2.12"
 PROTOBUF_VERSION="3.11.4"
-CURL_VERSION="7.85.0"
-AWS_SDK_CPP_VERSION="1.9.67"
-
-# 1.1.1.q is not stable for MacOS, downgraded to 1.1.1n
-# see https://github.com/openssl/openssl/issues/18720
-if [[ $(uname) == 'Darwin' ]]; then
-  OPENSSL_VERSION="1.1.1n"
-fi
+CURL_VERSION="7.86.0"
+AWS_SDK_CPP_VERSION="1.10.32"
 
 LIB_OPENSSL="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
 LIB_BOOST="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"
@@ -222,9 +216,10 @@ if [ ! -d "curl-${CURL_VERSION}" ]; then
   cd curl-${CURL_VERSION}
 
   if [[ $(uname) == 'Darwin' ]]; then
-    silence conf --disable-shared --disable-ldap --disable-ldaps --without-libidn2 \
-      --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-openssl
-
+    silence conf --with-openssl --enable-threaded-resolver \
+      --disable-shared --disable-ldap --disable-ldaps --disable-debug \
+      --without-libidn2 --without-libssh2 --without-ca-bundle \
+      --without-brotli --without-nghttp2 --without-librtmp --without-zstd
     # Apply a patch for macOS that should prevent curl from trying to use clock_gettime
     # This is a temporary work around for https://github.com/awslabs/amazon-kinesis-producer/issues/117
     # until dependencies are updated
@@ -255,7 +250,7 @@ if [ ! -d "aws-sdk-cpp" ]; then
   cd aws-sdk-cpp-build
 
   silence $CMAKE \
-    -DBUILD_ONLY="kinesis;monitoring" \
+    -DBUILD_ONLY="kinesis;monitoring;sts" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DSTATIC_LINKING=1 \
     -DCMAKE_PREFIX_PATH="$INSTALL_DIR" \

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.14.13</version>
+            <version>0.15.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.14.13</version>
+    <version>0.15.0-SNAPSHOT</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.5</version>
+            <version>3.21.7</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -113,6 +113,7 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty-no-dependencies</artifactId>
             <version>5.14.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
-    private static final String USER_AGENT_APP_NAME = "kpl-0.14.13";
+    private static final String USER_AGENT_APP_NAME = "kpl-0.15.0-SNAPSHOT";
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -25,7 +25,7 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -517,7 +517,7 @@ public class KinesisProducer implements IKinesisProducer {
      *            The hash value used to explicitly determine the shard the data
      *            record is assigned to by overriding the partition key hash.
      *            Must be a valid string representation of a positive integer
-     *            with value between 0 and <tt>2^128 - 1</tt> (inclusive).
+     *            with value between 0 and <code>2^128 - 1</code> (inclusive).
      * @param data
      *            Binary data of the record. Maximum size 1MiB.
      * @return A future for the result of the put.

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
@@ -368,6 +368,8 @@ public class KinesisProducerConfiguration {
     private long proxyPort = 443L;
     private String proxyUserName = "";
     private String proxyPassword = "";
+    private String stsEndpoint = "";
+    private long stsPort = 443L;
     private ThreadingModel threadingModel = ThreadingModel.PER_REQUEST;
     private int threadPoolSize = 0;
     private String caCertPath = "";
@@ -874,6 +876,30 @@ public class KinesisProducerConfiguration {
      */
     public String getProxyPassword() {
         return proxyPassword;
+    }
+
+    /**
+     * Get a custom STS endpoint.
+     *
+     * <p>
+     * Note this does not accept protocols or paths, only host names or ip addresses. There is no
+     * way to disable TLS. The KPL always connects with TLS.
+     *
+     * <p><b>Expected pattern</b>: ^([A-Za-z0-9-\\.]+)?$
+     */
+    public String getStsEndpoint() {
+      return stsEndpoint;
+    }
+
+    /**
+     * Server port to connect to for STS.
+     *
+     * <p><b>Default</b>: 443
+     * <p><b>Minimum</b>: 1
+     * <p><b>Maximum (inclusive)</b>: 65535
+     */
+    public long getStsPort() {
+      return stsPort;
     }
 
     /**
@@ -1528,10 +1554,42 @@ public class KinesisProducerConfiguration {
     }
 
     /**
+     * Use a custom STS endpoint.
+     *
+     * <p>
+     * Note this does not accept protocols or paths, only host names or ip addresses. There is no
+     * way to disable TLS. The KPL always connects with TLS.
+     *
+     * <p><b>Expected pattern</b>: ^([A-Za-z0-9-\\.]+)?$
+     */
+    public KinesisProducerConfiguration setStsEndpoint(String val) {
+        if (!Pattern.matches("^([A-Za-z0-9-\\.]+)?$", val)) {
+            throw new IllegalArgumentException("stsEndpoint must match the pattern ^([A-Za-z0-9-\\.]+)?$, got " + val);
+        }
+        stsEndpoint = val;
+        return this;
+    }
+
+    /**
+     * Server port to connect to for STS.
+     *
+     * <p><b>Default</b>: 443
+     * <p><b>Minimum</b>: 1
+     * <p><b>Maximum (inclusive)</b>: 65535
+     */
+    public KinesisProducerConfiguration setStsPort(long val) {
+        if (val < 1L || val > 65535L) {
+            throw new IllegalArgumentException("kinesisPort must be between 1 and 65535, got " + val);
+        }
+        stsPort = val;
+        return this;
+    }
+
+    /**
      * Sets the threading model that the native process will use.
      *
      * See {@link #getThreadingModel()} for more information
-     * 
+     *
      * @param threadingModel
      *            the threading model to use
      * @return this configuration object
@@ -1631,6 +1689,8 @@ public class KinesisProducerConfiguration {
                 .setProxyPort(proxyPort)
                 .setProxyUserName(proxyUserName)
                 .setProxyPassword(proxyPassword)
+                .setStsEndpoint(stsEndpoint)
+                .setStsPort(stsPort)
                 .setThreadConfig(threadingModel.threadConfig);
         //@formatter:on
         if (threadPoolSize > 0) {

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecord.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/UserRecord.java
@@ -11,6 +11,11 @@ public class UserRecord {
     private String streamName;
 
     /**
+     * ARN of the stream, e.g., arn:aws:kinesis:us-east-2:123456789012:stream/mystream
+     */
+    private String streamARN;
+
+    /**
      * Partition key. Length must be at least one, and at most 256 (inclusive).
      */
     private String partitionKey;
@@ -19,7 +24,7 @@ public class UserRecord {
      * The hash value used to explicitly determine the shard the data
      * record is assigned to by overriding the partition key hash.
      * Must be a valid string representation of a positive integer
-     * with value between 0 and <tt>2^128 - 1</tt> (inclusive).
+     * with value between 0 and <code>2^128 - 1</code> (inclusive).
      */
     private String explicitHashKey;
 

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/protobuf/Config.java
@@ -1404,6 +1404,34 @@ public final class Config {
         getProxyPasswordBytes();
 
     /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return Whether the stsEndpoint field is set.
+     */
+    boolean hasStsEndpoint();
+    /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return The stsEndpoint.
+     */
+    java.lang.String getStsEndpoint();
+    /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return The bytes for stsEndpoint.
+     */
+    com.google.protobuf.ByteString
+        getStsEndpointBytes();
+
+    /**
+     * <code>optional uint64 sts_port = 33 [default = 443];</code>
+     * @return Whether the stsPort field is set.
+     */
+    boolean hasStsPort();
+    /**
+     * <code>optional uint64 sts_port = 33 [default = 443];</code>
+     * @return The stsPort.
+     */
+    long getStsPort();
+
+    /**
      * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];</code>
      * @return Whether the threadConfig field is set.
      */
@@ -1466,6 +1494,8 @@ public final class Config {
       proxyPort_ = 443L;
       proxyUserName_ = "";
       proxyPassword_ = "";
+      stsEndpoint_ = "";
+      stsPort_ = 443L;
       threadConfig_ = 0;
       threadPoolSize_ = 64;
     }
@@ -1491,6 +1521,7 @@ public final class Config {
         throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
+      int mutable_bitField1_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -1663,14 +1694,25 @@ public final class Config {
               if (value == null) {
                 unknownFields.mergeVarintField(30, rawValue);
               } else {
-                bitField0_ |= 0x20000000;
+                bitField0_ |= 0x80000000;
                 threadConfig_ = rawValue;
               }
               break;
             }
             case 248: {
-              bitField0_ |= 0x40000000;
+              bitField1_ |= 0x00000001;
               threadPoolSize_ = input.readUInt32();
+              break;
+            }
+            case 258: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x20000000;
+              stsEndpoint_ = bs;
+              break;
+            }
+            case 264: {
+              bitField0_ |= 0x40000000;
+              stsPort_ = input.readUInt64();
               break;
             }
             case 1026: {
@@ -1814,6 +1856,7 @@ public final class Config {
     }
 
     private int bitField0_;
+    private int bitField1_;
     public static final int ADDITIONAL_METRIC_DIMS_FIELD_NUMBER = 128;
     private java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> additionalMetricDims_;
     /**
@@ -1825,7 +1868,7 @@ public final class Config {
     /**
      * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
      */
-    public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
+    public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder>
         getAdditionalMetricDimsOrBuilderList() {
       return additionalMetricDims_;
     }
@@ -1918,7 +1961,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -1935,7 +1978,7 @@ public final class Config {
         getCloudwatchEndpointBytes() {
       java.lang.Object ref = cloudwatchEndpoint_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         cloudwatchEndpoint_ = b;
@@ -2065,7 +2108,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2082,7 +2125,7 @@ public final class Config {
         getKinesisEndpointBytes() {
       java.lang.Object ref = kinesisEndpoint_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         kinesisEndpoint_ = b;
@@ -2127,7 +2170,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2144,7 +2187,7 @@ public final class Config {
         getLogLevelBytes() {
       java.lang.Object ref = logLevel_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         logLevel_ = b;
@@ -2189,7 +2232,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2206,7 +2249,7 @@ public final class Config {
         getMetricsGranularityBytes() {
       java.lang.Object ref = metricsGranularity_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         metricsGranularity_ = b;
@@ -2234,7 +2277,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2251,7 +2294,7 @@ public final class Config {
         getMetricsLevelBytes() {
       java.lang.Object ref = metricsLevel_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         metricsLevel_ = b;
@@ -2279,7 +2322,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2296,7 +2339,7 @@ public final class Config {
         getMetricsNamespaceBytes() {
       java.lang.Object ref = metricsNamespace_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         metricsNamespace_ = b;
@@ -2409,7 +2452,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2426,7 +2469,7 @@ public final class Config {
         getRegionBytes() {
       java.lang.Object ref = region_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         region_ = b;
@@ -2488,7 +2531,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2505,7 +2548,7 @@ public final class Config {
         getProxyHostBytes() {
       java.lang.Object ref = proxyHost_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         proxyHost_ = b;
@@ -2550,7 +2593,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2567,7 +2610,7 @@ public final class Config {
         getProxyUserNameBytes() {
       java.lang.Object ref = proxyUserName_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         proxyUserName_ = b;
@@ -2595,7 +2638,7 @@ public final class Config {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        com.google.protobuf.ByteString bs = 
+        com.google.protobuf.ByteString bs =
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
@@ -2612,7 +2655,7 @@ public final class Config {
         getProxyPasswordBytes() {
       java.lang.Object ref = proxyPassword_;
       if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         proxyPassword_ = b;
@@ -2622,6 +2665,68 @@ public final class Config {
       }
     }
 
+    public static final int STS_ENDPOINT_FIELD_NUMBER = 32;
+    private volatile java.lang.Object stsEndpoint_;
+    /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return Whether the stsEndpoint field is set.
+     */
+    public boolean hasStsEndpoint() {
+      return ((bitField0_ & 0x20000000) != 0);
+    }
+    /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return The stsEndpoint.
+     */
+    public java.lang.String getStsEndpoint() {
+      java.lang.Object ref = stsEndpoint_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          stsEndpoint_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string sts_endpoint = 32 [default = ""];</code>
+     * @return The bytes for stsEndpoint.
+     */
+    public com.google.protobuf.ByteString
+        getStsEndpointBytes() {
+      java.lang.Object ref = stsEndpoint_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        stsEndpoint_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int STS_PORT_FIELD_NUMBER = 33;
+    private long stsPort_;
+    /**
+     * <code>optional uint64 sts_port = 33 [default = 443];</code>
+     * @return Whether the stsPort field is set.
+     */
+    public boolean hasStsPort() {
+      return ((bitField0_ & 0x40000000) != 0);
+    }
+    /**
+     * <code>optional uint64 sts_port = 33 [default = 443];</code>
+     * @return The stsPort.
+     */
+    public long getStsPort() {
+      return stsPort_;
+    }
+
     public static final int THREAD_CONFIG_FIELD_NUMBER = 30;
     private int threadConfig_;
     /**
@@ -2629,7 +2734,7 @@ public final class Config {
      * @return Whether the threadConfig field is set.
      */
     public boolean hasThreadConfig() {
-      return ((bitField0_ & 0x20000000) != 0);
+      return ((bitField0_ & 0x80000000) != 0);
     }
     /**
      * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];</code>
@@ -2648,7 +2753,7 @@ public final class Config {
      * @return Whether the threadPoolSize field is set.
      */
     public boolean hasThreadPoolSize() {
-      return ((bitField0_ & 0x40000000) != 0);
+      return ((bitField1_ & 0x00000001) != 0);
     }
     /**
      * <code>optional uint32 thread_pool_size = 31 [default = 64];</code>
@@ -2765,11 +2870,17 @@ public final class Config {
       if (((bitField0_ & 0x10000000) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 29, proxyPassword_);
       }
-      if (((bitField0_ & 0x20000000) != 0)) {
+      if (((bitField0_ & 0x80000000) != 0)) {
         output.writeEnum(30, threadConfig_);
       }
-      if (((bitField0_ & 0x40000000) != 0)) {
+      if (((bitField1_ & 0x00000001) != 0)) {
         output.writeUInt32(31, threadPoolSize_);
+      }
+      if (((bitField0_ & 0x20000000) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 32, stsEndpoint_);
+      }
+      if (((bitField0_ & 0x40000000) != 0)) {
+        output.writeUInt64(33, stsPort_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         output.writeMessage(128, additionalMetricDims_.get(i));
@@ -2889,13 +3000,20 @@ public final class Config {
       if (((bitField0_ & 0x10000000) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(29, proxyPassword_);
       }
-      if (((bitField0_ & 0x20000000) != 0)) {
+      if (((bitField0_ & 0x80000000) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(30, threadConfig_);
       }
-      if (((bitField0_ & 0x40000000) != 0)) {
+      if (((bitField1_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt32Size(31, threadPoolSize_);
+      }
+      if (((bitField0_ & 0x20000000) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(32, stsEndpoint_);
+      }
+      if (((bitField0_ & 0x40000000) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(33, stsPort_);
       }
       for (int i = 0; i < additionalMetricDims_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
@@ -3063,6 +3181,16 @@ public final class Config {
         if (!getProxyPassword()
             .equals(other.getProxyPassword())) return false;
       }
+      if (hasStsEndpoint() != other.hasStsEndpoint()) return false;
+      if (hasStsEndpoint()) {
+        if (!getStsEndpoint()
+            .equals(other.getStsEndpoint())) return false;
+      }
+      if (hasStsPort() != other.hasStsPort()) return false;
+      if (hasStsPort()) {
+        if (getStsPort()
+            != other.getStsPort()) return false;
+      }
       if (hasThreadConfig() != other.hasThreadConfig()) return false;
       if (hasThreadConfig()) {
         if (threadConfig_ != other.threadConfig_) return false;
@@ -3221,6 +3349,15 @@ public final class Config {
       if (hasProxyPassword()) {
         hash = (37 * hash) + PROXY_PASSWORD_FIELD_NUMBER;
         hash = (53 * hash) + getProxyPassword().hashCode();
+      }
+      if (hasStsEndpoint()) {
+        hash = (37 * hash) + STS_ENDPOINT_FIELD_NUMBER;
+        hash = (53 * hash) + getStsEndpoint().hashCode();
+      }
+      if (hasStsPort()) {
+        hash = (37 * hash) + STS_PORT_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getStsPort());
       }
       if (hasThreadConfig()) {
         hash = (37 * hash) + THREAD_CONFIG_FIELD_NUMBER;
@@ -3428,10 +3565,14 @@ public final class Config {
         bitField0_ = (bitField0_ & ~0x10000000);
         proxyPassword_ = "";
         bitField0_ = (bitField0_ & ~0x20000000);
-        threadConfig_ = 0;
+        stsEndpoint_ = "";
         bitField0_ = (bitField0_ & ~0x40000000);
-        threadPoolSize_ = 64;
+        stsPort_ = 443L;
         bitField0_ = (bitField0_ & ~0x80000000);
+        threadConfig_ = 0;
+        bitField1_ = (bitField1_ & ~0x00000001);
+        threadPoolSize_ = 64;
+        bitField1_ = (bitField1_ & ~0x00000002);
         return this;
       }
 
@@ -3459,7 +3600,9 @@ public final class Config {
       public com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration buildPartial() {
         com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration result = new com.amazonaws.services.kinesis.producer.protobuf.Config.Configuration(this);
         int from_bitField0_ = bitField0_;
+        int from_bitField1_ = bitField1_;
         int to_bitField0_ = 0;
+        int to_bitField1_ = 0;
         if (additionalMetricDimsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
             additionalMetricDims_ = java.util.Collections.unmodifiableList(additionalMetricDims_);
@@ -3588,12 +3731,21 @@ public final class Config {
         if (((from_bitField0_ & 0x40000000) != 0)) {
           to_bitField0_ |= 0x20000000;
         }
-        result.threadConfig_ = threadConfig_;
+        result.stsEndpoint_ = stsEndpoint_;
         if (((from_bitField0_ & 0x80000000) != 0)) {
           to_bitField0_ |= 0x40000000;
         }
+        result.stsPort_ = stsPort_;
+        if (((from_bitField1_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x80000000;
+        }
+        result.threadConfig_ = threadConfig_;
+        if (((from_bitField1_ & 0x00000002) != 0)) {
+          to_bitField1_ |= 0x00000001;
+        }
         result.threadPoolSize_ = threadPoolSize_;
         result.bitField0_ = to_bitField0_;
+        result.bitField1_ = to_bitField1_;
         onBuilt();
         return result;
       }
@@ -3660,7 +3812,7 @@ public final class Config {
               additionalMetricDimsBuilder_ = null;
               additionalMetricDims_ = other.additionalMetricDims_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              additionalMetricDimsBuilder_ = 
+              additionalMetricDimsBuilder_ =
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getAdditionalMetricDimsFieldBuilder() : null;
             } else {
@@ -3775,6 +3927,14 @@ public final class Config {
           proxyPassword_ = other.proxyPassword_;
           onChanged();
         }
+        if (other.hasStsEndpoint()) {
+          bitField0_ |= 0x40000000;
+          stsEndpoint_ = other.stsEndpoint_;
+          onChanged();
+        }
+        if (other.hasStsPort()) {
+          setStsPort(other.getStsPort());
+        }
         if (other.hasThreadConfig()) {
           setThreadConfig(other.getThreadConfig());
         }
@@ -3815,6 +3975,7 @@ public final class Config {
         return this;
       }
       private int bitField0_;
+      private int bitField1_;
 
       private java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension> additionalMetricDims_ =
         java.util.Collections.emptyList();
@@ -4011,7 +4172,7 @@ public final class Config {
       /**
        * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
-      public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
+      public java.util.List<? extends com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder>
            getAdditionalMetricDimsOrBuilderList() {
         if (additionalMetricDimsBuilder_ != null) {
           return additionalMetricDimsBuilder_.getMessageOrBuilderList();
@@ -4037,12 +4198,12 @@ public final class Config {
       /**
        * <code>repeated .aws.kinesis.protobuf.AdditionalDimension additional_metric_dims = 128;</code>
        */
-      public java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder> 
+      public java.util.List<com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder>
            getAdditionalMetricDimsBuilderList() {
         return getAdditionalMetricDimsFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder> 
+          com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension.Builder, com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimensionOrBuilder>
           getAdditionalMetricDimsFieldBuilder() {
         if (additionalMetricDimsBuilder_ == null) {
           additionalMetricDimsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
@@ -4201,7 +4362,7 @@ public final class Config {
           getCloudwatchEndpointBytes() {
         java.lang.Object ref = cloudwatchEndpoint_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           cloudwatchEndpoint_ = b;
@@ -4507,7 +4668,7 @@ public final class Config {
           getKinesisEndpointBytes() {
         java.lang.Object ref = kinesisEndpoint_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           kinesisEndpoint_ = b;
@@ -4628,7 +4789,7 @@ public final class Config {
           getLogLevelBytes() {
         java.lang.Object ref = logLevel_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           logLevel_ = b;
@@ -4749,7 +4910,7 @@ public final class Config {
           getMetricsGranularityBytes() {
         java.lang.Object ref = metricsGranularity_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           metricsGranularity_ = b;
@@ -4833,7 +4994,7 @@ public final class Config {
           getMetricsLevelBytes() {
         java.lang.Object ref = metricsLevel_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           metricsLevel_ = b;
@@ -4917,7 +5078,7 @@ public final class Config {
           getMetricsNamespaceBytes() {
         java.lang.Object ref = metricsNamespace_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           metricsNamespace_ = b;
@@ -5186,7 +5347,7 @@ public final class Config {
           getRegionBytes() {
         java.lang.Object ref = region_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           region_ = b;
@@ -5344,7 +5505,7 @@ public final class Config {
           getProxyHostBytes() {
         java.lang.Object ref = proxyHost_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           proxyHost_ = b;
@@ -5465,7 +5626,7 @@ public final class Config {
           getProxyUserNameBytes() {
         java.lang.Object ref = proxyUserName_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           proxyUserName_ = b;
@@ -5549,7 +5710,7 @@ public final class Config {
           getProxyPasswordBytes() {
         java.lang.Object ref = proxyPassword_;
         if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString b =
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
           proxyPassword_ = b;
@@ -5599,13 +5760,134 @@ public final class Config {
         return this;
       }
 
+      private java.lang.Object stsEndpoint_ = "";
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @return Whether the stsEndpoint field is set.
+       */
+      public boolean hasStsEndpoint() {
+        return ((bitField0_ & 0x40000000) != 0);
+      }
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @return The stsEndpoint.
+       */
+      public java.lang.String getStsEndpoint() {
+        java.lang.Object ref = stsEndpoint_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            stsEndpoint_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @return The bytes for stsEndpoint.
+       */
+      public com.google.protobuf.ByteString
+          getStsEndpointBytes() {
+        java.lang.Object ref = stsEndpoint_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          stsEndpoint_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @param value The stsEndpoint to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStsEndpoint(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x40000000;
+        stsEndpoint_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStsEndpoint() {
+        bitField0_ = (bitField0_ & ~0x40000000);
+        stsEndpoint_ = getDefaultInstance().getStsEndpoint();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sts_endpoint = 32 [default = ""];</code>
+       * @param value The bytes for stsEndpoint to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStsEndpointBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x40000000;
+        stsEndpoint_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long stsPort_ = 443L;
+      /**
+       * <code>optional uint64 sts_port = 33 [default = 443];</code>
+       * @return Whether the stsPort field is set.
+       */
+      public boolean hasStsPort() {
+        return ((bitField0_ & 0x80000000) != 0);
+      }
+      /**
+       * <code>optional uint64 sts_port = 33 [default = 443];</code>
+       * @return The stsPort.
+       */
+      public long getStsPort() {
+        return stsPort_;
+      }
+      /**
+       * <code>optional uint64 sts_port = 33 [default = 443];</code>
+       * @param value The stsPort to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStsPort(long value) {
+        bitField0_ |= 0x80000000;
+        stsPort_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint64 sts_port = 33 [default = 443];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStsPort() {
+        bitField0_ = (bitField0_ & ~0x80000000);
+        stsPort_ = 443L;
+        onChanged();
+        return this;
+      }
+
       private int threadConfig_ = 0;
       /**
        * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];</code>
        * @return Whether the threadConfig field is set.
        */
       public boolean hasThreadConfig() {
-        return ((bitField0_ & 0x40000000) != 0);
+        return ((bitField1_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .aws.kinesis.protobuf.Configuration.ThreadConfig thread_config = 30 [default = PER_REQUEST];</code>
@@ -5625,7 +5907,7 @@ public final class Config {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x40000000;
+        bitField1_ |= 0x00000001;
         threadConfig_ = value.getNumber();
         onChanged();
         return this;
@@ -5635,7 +5917,7 @@ public final class Config {
        * @return This builder for chaining.
        */
       public Builder clearThreadConfig() {
-        bitField0_ = (bitField0_ & ~0x40000000);
+        bitField1_ = (bitField1_ & ~0x00000001);
         threadConfig_ = 0;
         onChanged();
         return this;
@@ -5647,7 +5929,7 @@ public final class Config {
        * @return Whether the threadPoolSize field is set.
        */
       public boolean hasThreadPoolSize() {
-        return ((bitField0_ & 0x80000000) != 0);
+        return ((bitField1_ & 0x00000002) != 0);
       }
       /**
        * <code>optional uint32 thread_pool_size = 31 [default = 64];</code>
@@ -5662,7 +5944,7 @@ public final class Config {
        * @return This builder for chaining.
        */
       public Builder setThreadPoolSize(int value) {
-        bitField0_ |= 0x80000000;
+        bitField1_ |= 0x00000002;
         threadPoolSize_ = value;
         onChanged();
         return this;
@@ -5672,7 +5954,7 @@ public final class Config {
        * @return This builder for chaining.
        */
       public Builder clearThreadPoolSize() {
-        bitField0_ = (bitField0_ & ~0x80000000);
+        bitField1_ = (bitField1_ & ~0x00000002);
         threadPoolSize_ = 64;
         onChanged();
         return this;
@@ -5732,12 +6014,12 @@ public final class Config {
 
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_aws_kinesis_protobuf_AdditionalDimension_descriptor;
-  private static final 
+  private static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_aws_kinesis_protobuf_AdditionalDimension_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_aws_kinesis_protobuf_Configuration_descriptor;
-  private static final 
+  private static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable;
 
@@ -5751,7 +6033,7 @@ public final class Config {
     java.lang.String[] descriptorData = {
       "\n\014config.proto\022\024aws.kinesis.protobuf\"F\n\023" +
       "AdditionalDimension\022\013\n\003key\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\220\t\n\rConfigu" +
+      "e\030\002 \002(\t\022\023\n\013granularity\030\003 \002(\t\"\277\t\n\rConfigu" +
       "ration\022J\n\026additional_metric_dims\030\200\001 \003(\0132" +
       ").aws.kinesis.protobuf.AdditionalDimensi" +
       "on\022!\n\023aggregation_enabled\030\001 \001(\010:\004true\022)\n" +
@@ -5776,13 +6058,14 @@ public final class Config {
       "uest_timeout\030\030 \001(\004:\0046000\022 \n\022verify_certi" +
       "ficate\030\031 \001(\010:\004true\022\024\n\nproxy_host\030\032 \001(\t:\000" +
       "\022\027\n\nproxy_port\030\033 \001(\004:\003443\022\031\n\017proxy_user_" +
-      "name\030\034 \001(\t:\000\022\030\n\016proxy_password\030\035 \001(\t:\000\022T" +
-      "\n\rthread_config\030\036 \001(\01620.aws.kinesis.prot" +
-      "obuf.Configuration.ThreadConfig:\013PER_REQ" +
-      "UEST\022\034\n\020thread_pool_size\030\037 \001(\r:\00264\"+\n\014Th" +
-      "readConfig\022\017\n\013PER_REQUEST\020\000\022\n\n\006POOLED\020\001B" +
-      "2\n0com.amazonaws.services.kinesis.produc" +
-      "er.protobuf"
+      "name\030\034 \001(\t:\000\022\030\n\016proxy_password\030\035 \001(\t:\000\022\026" +
+      "\n\014sts_endpoint\030  \001(\t:\000\022\025\n\010sts_port\030! \001(\004" +
+      ":\003443\022T\n\rthread_config\030\036 \001(\01620.aws.kines" +
+      "is.protobuf.Configuration.ThreadConfig:\013" +
+      "PER_REQUEST\022\034\n\020thread_pool_size\030\037 \001(\r:\0026" +
+      "4\"+\n\014ThreadConfig\022\017\n\013PER_REQUEST\020\000\022\n\n\006PO" +
+      "OLED\020\001B2\n0com.amazonaws.services.kinesis" +
+      ".producer.protobuf"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -5799,7 +6082,7 @@ public final class Config {
     internal_static_aws_kinesis_protobuf_Configuration_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_aws_kinesis_protobuf_Configuration_descriptor,
-        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ProxyHost", "ProxyPort", "ProxyUserName", "ProxyPassword", "ThreadConfig", "ThreadPoolSize", });
+        new java.lang.String[] { "AdditionalMetricDims", "AggregationEnabled", "AggregationMaxCount", "AggregationMaxSize", "CloudwatchEndpoint", "CloudwatchPort", "CollectionMaxCount", "CollectionMaxSize", "ConnectTimeout", "EnableCoreDumps", "FailIfThrottled", "KinesisEndpoint", "KinesisPort", "LogLevel", "MaxConnections", "MetricsGranularity", "MetricsLevel", "MetricsNamespace", "MetricsUploadDelay", "MinConnections", "RateLimit", "RecordMaxBufferedTime", "RecordTtl", "Region", "RequestTimeout", "VerifyCertificate", "ProxyHost", "ProxyPort", "ProxyUserName", "ProxyPassword", "StsEndpoint", "StsPort", "ThreadConfig", "ThreadPoolSize", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
@@ -280,7 +280,8 @@ public class KinesisProducerTest {
                 .setRegion("us-west-1")
                 .setRecordTtl(200)
                 .setMetricsUploadDelay(100)
-                .setRecordTtl(100);
+                .setRecordTtl(100)
+                .setLogLevel("warning");
         if (provider != null) {
             cfg.setCredentialsProvider(provider);
         }


### PR DESCRIPTION
*Description of changes:*
1. In order for users to benefit from account endpoints, StreamARN is included into both ListShards and PutRecords requests
1. Updated few dependencies to the most recent versions: aws-sdk-cpp. curl, and openssl, zlib
1. Added the STS dependency for building the StreamARN
   - Include STS endpoint and STS port in the configuration, and protobuf is updated accordingly
   - When the STS call fails, the KPL would exit. Therefore we can assure that KPL is running with StreamARNs
1. Fixed issue 
  - #445
  - #452

*Testing*
- Compiled in OSX, and tested with `amazon-kinesis-producer-sample`

```
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2022-12-19 10:55:35.409865] [0x0000fe11][0x0000700009aea000] [info] [AWS Log: WARN](STSAssumeRoleWithWebIdentityCredentialsProvider)Token file must be specified to use STS AssumeRole web identity creds provider.
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2022-12-19 10:55:36.023747] [0x0000fe11][0x0000700009aea000] [info] [pipeline.h:218] StreamARN "arn:aws:kinesis:us-east-1:448057645220:stream/kpltest" has been successfully configured, and will be used in requests including ListShards and PutRecords
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2022-12-19 10:55:36.025112] [0x0000fe11][0x0000700009aea000] [info] [shard_map.cc:89] Updating shard map for stream "kpltest"
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Put 2000 of 200000 so far (1.00 %), 0 have completed (0.00 %)
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Oldest future as of now in millis is 994
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2022-12-19 10:55:36.626632] [0x0000fe11][0x000070000a191000] [info] [shard_map.cc:152] Successfully updated shard map for stream "kpltest" (arn: "arn:aws:kinesis:us-east-1:448057645220:stream/kpltest"). Found 4 shards
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Put 4000 of 200000 so far (2.00 %), 0 have completed (0.00 %)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
