### PR TITLE
Revert the upgrade of jakarta.xml.bind to be backward-compatible with Java8

### DIFF
--- a/aws/kinesis/main.cc
+++ b/aws/kinesis/main.cc
@@ -253,7 +253,9 @@ std::shared_ptr<aws::auth::MutableStaticCredentialsProvider> create_creds(const 
 
 std::string get_region(const aws::kinesis::core::Configuration& config) {
   if (!config.region().empty()) {
-    return config.region();
+    std::string region = config.region();
+    LOG(info) << "Region has been successfully set to " << region << " from user's input configuration";
+    return region;
   }
 
   Aws::Internal::EC2MetadataClient ec2_client;
@@ -264,6 +266,7 @@ std::string get_region(const aws::kinesis::core::Configuration& config) {
     throw 1;
   }
 
+  LOG(info) << "Region has been successfully set to " << region << " using EC2 metadata (IMDSV2)";
   return region;
 }
 

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -105,9 +105,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.0</version>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.7</version>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.xml.bind.DatatypeConverter;
+import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -25,7 +25,7 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
-import jakarta.xml.bind.DatatypeConverter;
+import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import jakarta.xml.bind.DatatypeConverter;
+import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Revert the upgrade of jakarta.xml.bind to be backward-compatible with Java8
- Add more logs to verify that IMDSV2 is used correctly for getting region info for KPL running in EC2 instances

*Test*
- Confirmed that both Java11 and Java8 can build successfully with recently introduced dependencies for javax
- IMDS validation
```
# Region is set in configuration
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2023-01-03 16:44:13.525020] [0x00008a94][0x000000011715b600] [info] [main.cc:257] Region has been successfully set to us-east-1 from user's input configuration
# Region is NOT set in configuration
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2023-01-04 00:56:42.318065] [0x00003389][0x0000ffff9076f010] [info] [main.cc:269] Region has been successfully set to us-west-2 using EC2 metadata (IMDSV2)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
