### PR TITLE
Remove the stream arn parameter when the next token is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelog
+### 0.15.5
+* [#482](https://github.com/awslabs/amazon-kinesis-producer/pull/482)  Remove the stream arn parameter when the next token is present
 
 ### 0.15.4
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ If you have further questions [please open a GitHub Issue](https://github.com/aw
 This is a restatement of the [notice published](https://docs.aws.amazon.com/streams/latest/dev/kinesis-kpl-upgrades.html) in the [Amazon Kinesis Data Streams Developer Guide][kinesis-developer-guide]
 
 ## Release Notes
+### 0.15.5
+* [#482](https://github.com/awslabs/amazon-kinesis-producer/pull/482)  Remove the stream arn parameter when the next token is present
+
 ### 0.15.4
 
 ### 0.15.3

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -45,7 +45,7 @@ struct EndpointConfiguration {
           sts_endpoint_(sts_endpoint) {}
 };
 
-const constexpr char* kVersion = "0.14.13N";
+const constexpr char* kVersion = "0.15.5N";
 const std::unordered_map< std::string, EndpointConfiguration > kRegionEndpointOverride = {
   { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } },
   { "cn-northwest-1", { "kinesis.cn-northwest-1.amazonaws.com.cn", "monitoring.cn-northwest-1.amazonaws.com.cn" } }

--- a/aws/kinesis/core/shard_map.cc
+++ b/aws/kinesis/core/shard_map.cc
@@ -103,7 +103,6 @@ void ShardMap::list_shards(const Aws::String& next_token) {
 
   if (!next_token.empty()) {
     req.SetNextToken(next_token);
-    if (!stream_arn_.empty()) req.SetStreamARN(stream_arn_);
   } else {
     req.SetStreamName(stream_);
     if (!stream_arn_.empty()) req.SetStreamARN(stream_arn_);

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.15.4</version>
+            <version>0.15.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.15.4</version>
+    <version>0.15.5</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
-    private static final String USER_AGENT_APP_NAME = "kpl-0.15.4";
+    private static final String USER_AGENT_APP_NAME = "kpl-0.15.5";
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-producer/issues/481

*Description of changes:*
- Remove the `StreamArn` parameter when ListShards fetches the next page using `NextToken`

* Testing*
Tested locally with the code snippet
```
void ShardMap::list_shards(const Aws::String& next_token) {
  Aws::Kinesis::Model::ListShardsRequest req;
  req.SetMaxResults(1);

  if (!next_token.empty()) {
    LOG(info) << "[DEBUG] Updating shard map for stream \"" << stream_ << "\", the max result has been set to 1";
    req.SetNextToken(next_token);
  } else {
...
  }
```
and verified that the next page of shards can be successfully loaded:
```
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2023-02-17 10:28:06.754721] [0x00007c48][0x0000700003987000] [info] [shard_map.cc:105] [DEBUG] Updating shard map for stream "kpltest", the max result has been set to 1
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Put 5999 of 200000 so far (3.00 %), 2000 have completed (1.00 %)
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Oldest future as of now in millis is 2000
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Put 7998 of 200000 so far (4.00 %), 4500 have completed (2.25 %)
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Oldest future as of now in millis is 1749
[kpl-daemon-0003] INFO com.amazonaws.services.kinesis.producer.LogInputStreamReader - [2023-02-17 10:28:08.309224] [0x00007c48][0x0000700003b93000] [info] [shard_map.cc:105] [DEBUG] Updating shard map for stream "kpltest", the max result has been set to 1
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Put 9998 of 200000 so far (5.00 %), 7000 have completed (3.50 %)
[pool-1-thread-1] INFO com.amazonaws.services.kinesis.producer.sample.SampleProducer - Oldest future as of now in millis is 1499
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
