### PR TITLE
Update the CMakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ set(STATIC_LIBS
         boost_chrono)
 
 find_package(Threads)
+find_package(ZLIB)
 find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring sts)
 
 add_library(LibCrypto STATIC IMPORTED)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the build error after upgrading the aws sdk cpp version
```
  Target "kinesis_producer" links to target "ZLIB::ZLIB" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
