### PR TITLE
Fix some memory leak cases in legacy code

### DIFF
--- a/aws/utils/logging.cc
+++ b/aws/utils/logging.cc
@@ -179,5 +179,9 @@ void setup_aws_logging(Aws::Utils::Logging::LogLevel log_level) {
     LOG(info) << "Set AWS Log Level to " << Aws::Utils::Logging::GetLogLevelName(log_level);
 }
 
+void teardown_aws_logging() {
+    Aws::Utils::Logging::ShutdownAWSLogging();
+}
+
 } //namespace utils
 } //namespace aws

--- a/aws/utils/logging.h
+++ b/aws/utils/logging.h
@@ -39,6 +39,7 @@ void setup_logging(const std::string& min_level = "info");
 void setup_logging(boost::log::trivial::severity_level level);
 
 void setup_aws_logging(Aws::Utils::Logging::LogLevel log_level);
+void teardown_aws_logging();
 
 } //namespace utils
 } //namespace aws

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,7 @@ BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.76.0 to 1_76
 ZLIB_VERSION="1.2.13"
 PROTOBUF_VERSION="3.11.4"
 CURL_VERSION="7.86.0"
-AWS_SDK_CPP_VERSION="1.11.59"
+AWS_SDK_CPP_VERSION="1.11.62"
 
 LIB_OPENSSL="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
 LIB_BOOST="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"


### PR DESCRIPTION
1. Upgrade SDK version to avoid s2n_cleanup related memory leak
2. Fix resource cleanup on KPL end to avoid memory leak