### PR TITLE
Dynamically link to local OpenSSL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,20 +214,24 @@ set(STATIC_LIBS
 find_package(Threads)
 find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring sts)
 
-add_library(LibCrypto STATIC IMPORTED)
-set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcrypto.a)
-set_property(TARGET LibCrypto PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${LIBDL_LIBRARIES})
+# add_library(LibCrypto STATIC IMPORTED)
+# set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcrypto.a)
+# set_property(TARGET LibCrypto PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${LIBDL_LIBRARIES})
 
-add_library(LibSsl STATIC IMPORTED)
-set_property(TARGET LibSsl PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libssl.a)
-set_property(TARGET LibSsl PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES LibCrypto)
+# add_library(LibSsl STATIC IMPORTED)
+# set_property(TARGET LibSsl PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libssl.a)
+# set_property(TARGET LibSsl PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES LibCrypto)
+
+# Find OpenSSL in your local system
+set(OPENSSL_ROOT_DIR /usr/include)
+find_package(OpenSSL REQUIRED)
 
 add_library(LibZ STATIC IMPORTED)
 set_property(TARGET LibZ PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libz.a)
 
 add_library(LibCurl STATIC IMPORTED)
 set_property(TARGET LibCurl PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcurl.a)
-set_property(TARGET LibCurl PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${LIBRT_LIBRARIES} ${LIBDL_LIBRARIES} LibSsl LibZ)
+set_property(TARGET LibCurl PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${LIBRT_LIBRARIES} ${LIBDL_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto LibZ)
 
 add_library(LibProto STATIC IMPORTED)
 set_property(TARGET LibProto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libprotobuf.a)
@@ -235,12 +239,16 @@ set_property(TARGET LibProto PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES LibZ)
 
 add_executable(kinesis_producer ${SOURCE_FILES} ${LOGGING_TRIGGERS} aws/kinesis/main.cc)
 target_include_directories(kinesis_producer SYSTEM PUBLIC ${THIRD_PARTY_INCLUDE})
-target_link_libraries(kinesis_producer ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} ${UUID_LIBRARIES} LibSsl LibCurl)
+target_link_libraries(kinesis_producer ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} ${UUID_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto LibCurl)
 
 add_executable(test_driver ${SOURCE_FILES} ${LOGGING_TRIGGERS} aws/kinesis/test_driver.cc)
 target_include_directories(test_driver SYSTEM PUBLIC ${THIRD_PARTY_INCLUDE})
-target_link_libraries(test_driver ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} ${UUID_LIBRARIES} LibSsl LibCurl)
+target_link_libraries(test_driver ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} ${UUID_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto LibCurl)
 
 add_executable(tests ${SOURCE_FILES} ${TESTS_SOURCE} ${LOGGING_TRIGGERS} aws/kinesis/test/test.cc)
 target_include_directories(tests SYSTEM PUBLIC ${THIRD_PARTY_INCLUDE})
-target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} boost_unit_test_framework ${UUID_LIBRARIES} LibSsl LibCurl)
+target_link_libraries(tests ${CMAKE_THREAD_LIBS_INIT} LibProto ${AWSSDK_LINK_LIBRARIES} ${LIBBACKTRACE_LIBRARIES} ${STATIC_LIBS} boost_unit_test_framework ${UUID_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto LibCurl)
+
+message(STATUS "OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+message(STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+message(STATUS "OpenSSL version: ${OPENSSL_VERSION}")

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -118,35 +118,35 @@ function conf {
 }
 
 # OpenSSL
-if [ ! -d "openssl-${OPENSSL_VERSION}" ]; then
+# if [ ! -d "openssl-${OPENSSL_VERSION}" ]; then
 
-  _curl "$LIB_OPENSSL" >openssl.tgz
-  tar xf openssl.tgz
-  rm openssl.tgz
+#   _curl "$LIB_OPENSSL" >openssl.tgz
+#   tar xf openssl.tgz
+#   rm openssl.tgz
 
-  cd openssl-${OPENSSL_VERSION}
-  OPTS="threads no-shared no-idea no-camellia no-seed no-bf no-cast no-rc2 no-rc5 no-md2 no-mdc2 no-ssl2 no-ssl3 no-capieng no-dso"
+#   cd openssl-${OPENSSL_VERSION}
+#   OPTS="threads no-shared no-idea no-camellia no-seed no-bf no-cast no-rc2 no-rc5 no-md2 no-mdc2 no-ssl2 no-ssl3 no-capieng no-dso"
 
-  if [[ $(uname) == 'Darwin' ]]; then
-    OPTS="$OPTS darwin64-x86_64-cc enable-ec_nistp_64_gcc_128"
-    silence ./Configure $OPTS --prefix="$INSTALL_DIR"
-  elif [[ $(uname) == MINGW* ]]; then
-    silence ./Configure mingw64 $OPTS --prefix="$INSTALL_DIR"
-    find ./ -name Makefile | while read f; do
-      echo >>"$f"
-      echo "%.o: %.c" >>"$f"
-      echo -e '\t$(COMPILE.c) $(OUTPUT_OPTION) $<;' >>$f
-    done
-  else
-    silence ./config $OPTS --prefix="$INSTALL_DIR"
-  fi
+#   if [[ $(uname) == 'Darwin' ]]; then
+#     OPTS="$OPTS darwin64-x86_64-cc enable-ec_nistp_64_gcc_128"
+#     silence ./Configure $OPTS --prefix="$INSTALL_DIR"
+#   elif [[ $(uname) == MINGW* ]]; then
+#     silence ./Configure mingw64 $OPTS --prefix="$INSTALL_DIR"
+#     find ./ -name Makefile | while read f; do
+#       echo >>"$f"
+#       echo "%.o: %.c" >>"$f"
+#       echo -e '\t$(COMPILE.c) $(OUTPUT_OPTION) $<;' >>$f
+#     done
+#   else
+#     silence ./config $OPTS --prefix="$INSTALL_DIR"
+#   fi
 
-  silence make depend
-  silence make # don't use -j, doesn't work half the time
-  silence make install
+#   silence make depend
+#   silence make # don't use -j, doesn't work half the time
+#   silence make install
 
-  cd ..
-fi
+#   cd ..
+# fi
 
 # Boost C++ Libraries
 if [ ! -d "boost_${BOOST_VERSION_UNDERSCORED}" ]; then
@@ -227,7 +227,7 @@ if [ ! -d "curl-${CURL_VERSION}" ]; then
     sed -Ei .bak 's/#define HAVE_CLOCK_GETTIME_MONOTONIC 1//' lib/curl_config.h
   else
     silence conf --disable-shared --disable-ldap --disable-ldaps --without-libidn2 \
-      --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-ssl="${INSTALL_DIR}" --without-libidn
+      --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-ssl --without-libidn
   fi
 
   silence make -j
@@ -272,7 +272,7 @@ cd ..
 
 # Build the native kinesis producer
 $CMAKE -DCMAKE_PREFIX_PATH="$INSTALL_DIR" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
-make -j8
+make -j4
 
 #copy native producer to a location that the java producer can package it
 NATIVE_BINARY_DIR=java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/$RELEASE_TYPE/


### PR DESCRIPTION


*Description of changes:* This is an example code for dynamically linking to the OpenSSL in your OS, instead of statically link it with the downloaded version. This can be helpful if you want to make sure the KPL is FIPS compliant.

Steps to build it (using a RHEL docker image as an example):
1. `docker run -ti redhat/ubi8 /bin/bash`
2. `yum install -y git make wget gcc gcc-c++ perl cmake libstdc++-static.x86_64 libuuid-devel.x86_64 maven java-11-openjdk-devel.x86_64`
3. [Optional] For my docker image, there was no pre-installed OpenSSL, so I have to download one to reproduce the customer scenario: `yum install openssl-devel`
	1. In my case, the paths are
```
$ whereis openssl
openssl: /usr/bin/openssl /usr/include/openssl /usr/share/man/man1/openssl.1ssl.gz
```
3. `git clone https://github.com/awslabs/amazon-kinesis-producer.git`
4. make the code change in this PR
5. Copy and pasted your AWS credential, since a unit test will use it
6. build it by running `./bootstrap.sh`
	1. In the output you can find an output message
```
-- OpenSSL include dir: /usr/include
-- OpenSSL libraries: /usr/lib64/libssl.so;/usr/lib64/libcrypto.so
-- OpenSSL version: 1.1.1k
```
Which is outputted by CMAKE file, which shows that the we are using the OpenSSL version pre-installed in your OS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
