### PR TITLE
Remove Guava dependency, use CompletableFuture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # VS Code
 .vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ ClickEvent event = inputQueue.take();
         }
         recordsPut.getAndIncrement();
 
-        ListenableFuture<UserRecordResult> f =
+        CompletableFuture<UserRecordResult> f =
                 kpl.addUserRecord(STREAM_NAME, partitionKey, data);
-        Futures.addCallback(f, new FutureCallback<UserRecordResult>() {
+        f.whenCompleteAsync(f, new BiConusmer<UserRecordResult, Throwable>() {
           ...
           ...
 ````

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -11,8 +11,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/java/amazon-kinesis-producer-sample/src/com/amazonaws/services/kinesis/producer/sample/MetricsAwareSampleProducer.java
+++ b/java/amazon-kinesis-producer-sample/src/com/amazonaws/services/kinesis/producer/sample/MetricsAwareSampleProducer.java
@@ -16,11 +16,13 @@
 package com.amazonaws.services.kinesis.producer.sample;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
+import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,10 +32,6 @@ import com.amazonaws.services.kinesis.producer.KinesisProducer;
 import com.amazonaws.services.kinesis.producer.Metric;
 import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * If you haven't looked at {@link SampleProducer}, do so first.
@@ -77,9 +75,17 @@ public class MetricsAwareSampleProducer {
         final KinesisProducer kinesisProducer = new KinesisProducer(config);
         
         // Result handler
-        final FutureCallback<UserRecordResult> callback = new FutureCallback<UserRecordResult>() {
+        final BiConsumer<UserRecordResult, Throwable> callback = new BiConsumer<UserRecordResult, Throwable>() {
             @Override
-            public void onFailure(Throwable t) {
+            public void accept(UserRecordResult userRecordResult, Throwable throwable) {
+                if(userRecordResult != null) {
+                    onSuccess(userRecordResult);
+                } else {
+                    onFailure(throwable);
+                }
+            }
+
+            void onFailure(Throwable t) {
                 if (t instanceof UserRecordFailedException) {
                     Attempt last = Iterables.getLast(
                             ((UserRecordFailedException) t).getResult().getAttempts());
@@ -91,8 +97,7 @@ public class MetricsAwareSampleProducer {
                 System.exit(1);
             }
 
-            @Override
-            public void onSuccess(UserRecordResult result) {
+            void onSuccess(UserRecordResult result) {
                 completed.getAndIncrement();
             }
         };
@@ -154,14 +159,14 @@ public class MetricsAwareSampleProducer {
         
         // Put records
         while (true) {
-            // We're going to put as fast as we can until we've reached the max
+            // We're going to putÏ as fast as we can until we've reached the max
             // number of records outstanding.
             if (sequenceNumber.get() < totalRecordsToPut) {
                 if (kinesisProducer.getOutstandingRecordsCount() < outstandingLimit) {
                     ByteBuffer data = Utils.generateData(sequenceNumber.incrementAndGet(), dataSize);
-                    ListenableFuture<UserRecordResult> f = kinesisProducer.addUserRecord(SampleProducerConfig.STREAM_NAME_DEFAULT,
+                    CompletableFuture<UserRecordResult> f = kinesisProducer.addUserRecord(SampleProducerConfig.STREAM_NAME_DEFAULT,
                             timetstamp, data);
-                    Futures.addCallback(f, callback, Executors.newSingleThreadExecutor());
+                    f.whenCompleteAsync(callback, Executors.newSingleThreadExecutor());
                 } else {
                     Thread.sleep(1);
                 }

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -64,11 +64,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.0</version>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/IKinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/IKinesisProducer.java
@@ -2,19 +2,19 @@ package com.amazonaws.services.kinesis.producer;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.amazonaws.services.schemaregistry.common.Schema;
 
 
 public interface IKinesisProducer {
-    ListenableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, ByteBuffer data);
+    CompletableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, ByteBuffer data);
 
-    ListenableFuture<UserRecordResult> addUserRecord(UserRecord userRecord);
+    CompletableFuture<UserRecordResult> addUserRecord(UserRecord userRecord);
 
-    ListenableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, String explicitHashKey, ByteBuffer data);
+    CompletableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, String explicitHashKey, ByteBuffer data);
 
-    ListenableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, String explicitHashKey, ByteBuffer data, Schema schema);
+    CompletableFuture<UserRecordResult> addUserRecord(String stream, String partitionKey, String explicitHashKey, ByteBuffer data, Schema schema);
 
     int getOutstandingRecordsCount();
 


### PR DESCRIPTION
*Description of changes:*

A proposal to use `CompletableFuture` instead of `ListenableFuture`.

Currently the KPL uses `ListenableFuture`, which was introduced by Guava prior to Java 8's release of `CompletableFuture`. Since the build for the KPL targets Java 8, it didn't seem to make much sense to continue to use Guava here. Much of the ecosystem has built abstractions and libraries around `CompletableFuture` use, so it makes sense for the KPL to follow that lead. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
