### PR TITLE
Drop dependency on jaxb for converting binary arrays to hex

### DIFF
--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -105,21 +105,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.3.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.7</version>
-        </dependency>
-        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty-no-dependencies</artifactId>
             <version>5.14.0</version>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/BinaryToHexConverter.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/BinaryToHexConverter.java
@@ -1,0 +1,28 @@
+package com.amazonaws.services.kinesis.producer;
+
+public class BinaryToHexConverter {
+
+	private static final BinaryToHexConverter INSTANCE = new BinaryToHexConverter();
+	private static final char[] HEX_CODE = "0123456789ABCDEF".toCharArray();
+
+	/**
+	 * Converts an array of bytes into a hex string.
+	 *
+	 * @param data An array of bytes
+	 * @return A string containing a lexical representation of xsd:hexBinary
+	 * @throws IllegalArgumentException if {@code data} is null.
+	 */
+	public static String convert(byte[] data) {
+		return INSTANCE.convertToHex(data);
+	}
+
+	private String convertToHex(byte[] data) {
+		StringBuilder r = new StringBuilder(data.length * 2);
+		for (byte b : data) {
+			r.append(HEX_CODE[(b >> 4) & 0xF]);
+			r.append(HEX_CODE[(b & 0xF)]);
+		}
+		return r.toString();
+	}
+
+}

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/Daemon.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -582,6 +581,6 @@ public class Daemon {
     }
     
     private static String protobufToHex(com.google.protobuf.Message msg) {
-        return DatatypeConverter.printHexBinary(msg.toByteArray());
+        return BinaryToHexConverter.convert(msg.toByteArray());
     }
 }

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/HashedFileCopier.java
@@ -25,8 +25,6 @@ import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +51,7 @@ public class HashedFileCopier {
             digestOutputStream.close();
             byte[] digest = digestOutputStream.getMessageDigest().digest();
             log.debug("Calculated digest of new file: {}", Arrays.toString(digest));
-            String digestHex = DatatypeConverter.printHexBinary(digest);
+            String digestHex = BinaryToHexConverter.convert(digest);
             File finalFile = new File(destinationDirectory, String.format(fileNameFormat, digestHex));
             File lockFile = new File(destinationDirectory, String.format(fileNameFormat + LOCK_SUFFIX, digestHex));
             log.debug("Preparing to check and copy {} to {}", tempFile.getAbsolutePath(), finalFile.getAbsolutePath());

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/BinaryToHexConverterTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/BinaryToHexConverterTest.java
@@ -1,0 +1,15 @@
+package com.amazonaws.services.kinesis.producer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BinaryToHexConverterTest {
+
+	@Test
+	public void testConvert() {
+		byte[] bytes = {0, 1, 2, 3, 124, 125, 126, 127};
+		assertEquals("000102037C7D7E7F", BinaryToHexConverter.convert(bytes));
+	}
+
+}

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/HashedFileCopierTest.java
@@ -27,8 +27,6 @@ import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -150,7 +148,7 @@ public class HashedFileCopierTest {
     }
 
     private String hexDigestForTestData() throws Exception {
-        return DatatypeConverter.printHexBinary(hashForTestData());
+        return BinaryToHexConverter.convert(hashForTestData());
     }
 
     private byte[] testDataBytes() throws Exception {


### PR DESCRIPTION
*Issue #, if available:*
This is related to https://github.com/awslabs/amazon-kinesis-producer/issues/452 and would remove the need for https://github.com/awslabs/amazon-kinesis-producer/pull/522.

*Description of changes:*
The jaxb depedency (`javax.xml.bind`) is used in a couple of classes to convert a binary array to a hex string. As suggested in https://github.com/awslabs/amazon-kinesis-producer/issues/452#issuecomment-1371445572 it is possible to drop the dependency and just have a simple converter instead. This will also remove the need to care about potential `jakarta` namespace switch in the future. This is important because currently trying to use the kinesis-producer library together with Spring 6 + latest Spring JPA/Hibernate results in errors. Removing the jaxb dependency from the kinesis-producer library fixes this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
