### PR TITLE
prepare for KPL release 0.15.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+## 0.15.9
+* [#552](https://github.com/awslabs/amazon-kinesis-producer/pull/552) Add StreamARN parameter to support CAA
+    * StreamARN parameter can be now be used to benefit from Cross account access for KPL requests.
 ## 0.15.8
 * [#537](https://github.com/awslabs/amazon-kinesis-producer/pull/537) Update to latest version of Glue Schema Registry library
  

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If you have further questions [please open a GitHub Issue](https://github.com/aw
 This is a restatement of the [notice published](https://docs.aws.amazon.com/streams/latest/dev/kinesis-kpl-upgrades.html) in the [Amazon Kinesis Data Streams Developer Guide][kinesis-developer-guide]
 
 ## Release Notes
+## 0.15.9
+* [#552](https://github.com/awslabs/amazon-kinesis-producer/pull/552) Add StreamARN parameter to support CAA
+    * StreamARN parameter can be now be used to benefit from Cross account access for KPL requests.
+    
 ## 0.15.8
 * [#537](https://github.com/awslabs/amazon-kinesis-producer/pull/537) Update to latest version of Glue Schema Registry library
 

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>0.15.8</version>
+            <version>0.15.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>0.15.8</version>
+    <version>0.15.9</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
-    private static final String USER_AGENT_APP_NAME = "kpl-0.15.8";
+    private static final String USER_AGENT_APP_NAME = "kpl-0.15.9";
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Preparing for KPL release 0.15.9
 [[#552](https://github.com/awslabs/amazon-kinesis-producer/pull/552)] Add StreamARN parameter to support CAA
    * StreamARN parameter can be now be used to benefit from Cross account access for KPL requests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
