### PR TITLE
check if dimension value is blank before using it

### DIFF
--- a/aws/metrics/metrics_manager.cc
+++ b/aws/metrics/metrics_manager.cc
@@ -32,6 +32,12 @@ std::shared_ptr<Metric> MetricsFinderBuilder::find() {
   return manager_.get_metric(mf_);
 }
 
+bool is_blank(const std::string& str) {
+  return std::all_of(str.begin(), str.end(), [](const unsigned char c) {
+    return std::isblank(c);
+  });
+}
+
 Aws::CloudWatch::Model::MetricDatum
 to_sdk_metric_datum(const std::shared_ptr<Metric> m, int numBuckets) {
   auto& a = m->accumulator();
@@ -47,7 +53,7 @@ to_sdk_metric_datum(const std::shared_ptr<Metric> m, int numBuckets) {
   for (auto& p : m->all_dimensions()) {
     if (p.first == "MetricName") {
       d.SetMetricName(p.second);
-    } else {
+    } else if (!is_blank(p.second)) {
       Aws::CloudWatch::Model::Dimension dim;
       dim.SetName(p.first);
       dim.SetValue(p.second);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-producer/issues/437

*Description of changes:*

CloudWatch will throw the `MissingParameter: The parameter MetricData.member.x.Dimensions.member.y.Value is required.` error if a `Dimension.value` is an empty string or contains only whitespace.

So, to prevent the error, I added a simple check to make sure a value is not empty or all whitespace before we create a `Dimension` with it.

Unfortunately, I was not able to run the test suite for this project, so I regrettably have not included a unit test.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
