### PR TITLE
Fix build issue after cpp sdk upgrade

### DIFF
--- a/aws/kinesis/core/pipeline.h
+++ b/aws/kinesis/core/pipeline.h
@@ -70,7 +70,7 @@ class Pipeline : boost::noncopyable {
         shard_map_(
             std::make_shared<ShardMap>(
                 executor_,
-                [this](auto& req, auto& handler, auto& context) { kinesis_client_->ListShardsAsync(req, handler, context); },
+                [this](auto& req, auto& handler, auto& context) { kinesis_client_->ListShardsAsync(handler, context, req ); },
                 stream_,
                 stream_arn_,
                 metrics_manager_)),

--- a/aws/kinesis/core/test/shard_map_test.cc
+++ b/aws/kinesis/core/test/shard_map_test.cc
@@ -55,10 +55,9 @@ class MockKinesisClient : public Aws::Kinesis::KinesisClient {
         executor_(std::make_shared<aws::utils::IoServiceExecutor>(1)) {}
   
   virtual void ListShardsAsync(
-      const Aws::Kinesis::Model::ListShardsRequest& request,
       const Aws::Kinesis::ListShardsResponseReceivedHandler& handler,
-      const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context
-          = nullptr) const {
+      const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context = nullptr,
+      const Aws::Kinesis::Model::ListShardsRequest& request = {}) const {
     executor_->schedule([=] {
     
       if (outcomes_list_shards_.size() == 0) {
@@ -89,7 +88,7 @@ class Wrapper {
                 [this] { num_req_received_++; }),
     shard_map_(
             std::make_shared<aws::utils::IoServiceExecutor>(1),
-            [this](auto& req, auto& handler, auto& context) { mock_kinesis_client_.ListShardsAsync(req, handler, context); },
+            [this](auto& req, auto& handler, auto& context) { mock_kinesis_client_.ListShardsAsync(handler, context, req); },
             kStreamName,
             kStreamARN,
             std::make_shared<aws::metrics::NullMetricsManager>(),

--- a/aws/utils/logging.cc
+++ b/aws/utils/logging.cc
@@ -147,6 +147,11 @@ public:
     va_end(args);
   }
 
+  // cpp sdk made this virtual so needed to have a dummy implementation for it for build to pass
+  virtual void vaLog(LogLevel logLevel, const char* tag, const char* formatStr, va_list args) override {
+    return;
+  }
+
   virtual void LogStream(LogLevel logLevel, const char* tag, const Aws::OStringStream &messageStream) override {
     LogToBoost(logLevel, tag, messageStream.str());
   }


### PR DESCRIPTION
*Issue #, if available:*
N/a
*Description of changes:*
Fix build after upgrading CPP SDK version.
The SDK upgrade caused two failures:
1. ListShardAsync argument order is changed from listShardAsync(req, handler, context) to listShardAsync(handler, context, req)
2. The interface `LogSystemInterface` has an addition of a none default interface method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
