### PR TITLE
Support building on Alpine Linux musl

### DIFF
--- a/aws/utils/backtrace/bsd_backtrace.cc
+++ b/aws/utils/backtrace/bsd_backtrace.cc
@@ -15,10 +15,10 @@
 
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
-#include <execinfo.h>
 #include <unistd.h>
 
 #ifdef BSD_BACKTRACE
+#include <execinfo.h>
 namespace aws {
 namespace utils {
 namespace backtrace {

--- a/aws/utils/backtrace/gcc_backtrace.cc
+++ b/aws/utils/backtrace/gcc_backtrace.cc
@@ -15,7 +15,6 @@
 
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
-#include <execinfo.h>
 #include <unistd.h>
 #include <aws/utils/logging.h>
 #include <aws/utils/writer_methods.h>
@@ -23,7 +22,7 @@
 #include <cstdio>
 
 #ifdef LIB_BACKTRACE
-
+#include <execinfo.h>
 #include <backtrace.h>
 
 namespace {

--- a/aws/utils/backtrace/null_backtrace.cc
+++ b/aws/utils/backtrace/null_backtrace.cc
@@ -15,10 +15,9 @@
 
 #include "backtrace.h"
 #include <aws/utils/writer_methods.h>
-#include <execinfo.h>
 #include <unistd.h>
 
-#ifdef NULL_STACKTRACE
+#ifdef NULL_BACKTRACE
 
 namespace aws {
 namespace utils {
@@ -36,4 +35,4 @@ void stack_trace_for_signal(int skip, bool /*signaled*/) {
 }
 }
 
-#endif // NULL_STACKTRACE
+#endif // NULL_BACKTRACE

--- a/aws/utils/signal_handler.cc
+++ b/aws/utils/signal_handler.cc
@@ -19,7 +19,6 @@
 #include "backtrace/backtrace.h"
 
 #include <signal.h>
-#include <execinfo.h>
 #include <unistd.h>
 #include <cstring>
 #include <cstdint>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -40,6 +40,9 @@ function find_release_type() {
   if [[ $OSTYPE == "linux-gnu" ]]; then
     echo "linux-$(uname -m)"
     return
+  elif [[ $OSTYPE == "linux-musl" ]]; then
+    echo "linux-musl-$(uname -m)"
+    return
   elif [[ $OSTYPE == darwin* ]]; then
     echo "osx"
     return


### PR DESCRIPTION
*Issue #, if available:* 
- Related to addressing the lack of Alpine Linux support and invalid workarounds to run on Alpine Linux , #86
  - Problem of installing glibc is explained [in a comment on this issue](https://github.com/awslabs/amazon-kinesis-producer/issues/86#issuecomment-2382928915). Mixing real glibc in Alpine will result in an unstable environment.

*Description of changes:*

- fix issue with NULL_BACKTRACE support (there was a typo: `NULL_STACKTRACE`)
- support building without libexecinfo (Alpine doesn't have it)
  - move `#include <execinfo.h>` under ifdef
  - remove `#include <execinfo.h>` from null_backtrace
- support linux-musl OSTYPE in bootstrap.sh

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Additional context:*

I'm working on Apache Pulsar's Pulsar IO Kinesis Sink connector. In Pulsar, we have applied the glibc workaround in an Alpine image and have run into stability issues. To address this, I'm fixing this by compiling the `kinesis_producer` binary and embedding this in Pulsar's docker image which is used to run Pulsar IO connectors. Since the Amazon Kinesis Producer library has a way to configure to use a custom `kinesis_producer` binary, that's how I'm planning to use it in Pulsar. It would be useful for other Alpine users if AWS could provide Alpine support directly out-of-the-box for the amazon-kinesis-producer library. I haven't yet fully tested the Alpine Linux support with the compiled binary since that's currently work-in-progress. I'll update this PR if I find out other incompatibilities in compilation. I'll also share more details later how to compile the binary in Docker with Alpine Linux.