### PR TITLE
Upgrade curl, openssl, zlib, and schema-registry-serde

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(amazon_kinesis_producer)
 include(CheckCCompilerFlag)
 
 set(THIRD_PARTY_LIB_DIR "${amazon_kinesis_producer_SOURCE_DIR}/third_party/lib")
+set(THIRD_PARTY_LIB64_DIR "${amazon_kinesis_producer_SOURCE_DIR}/third_party/lib64")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(ADDL_LINK_CONFIG "-static-libstdc++")
@@ -240,11 +241,11 @@ foreach(proto ${PROTO_FILES})
 endforeach()
 
 add_library(LibCrypto STATIC IMPORTED)
-set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libcrypto.a)
+set_property(TARGET LibCrypto PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB64_DIR}/libcrypto.a)
 set_property(TARGET LibCrypto PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${LIBDL_LIBRARIES})
 
 add_library(LibSsl STATIC IMPORTED)
-set_property(TARGET LibSsl PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB_DIR}/libssl.a)
+set_property(TARGET LibSsl PROPERTY IMPORTED_LOCATION ${THIRD_PARTY_LIB64_DIR}/libssl.a)
 set_property(TARGET LibSsl PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES LibCrypto)
 
 add_library(LibZ STATIC IMPORTED)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,16 +12,16 @@ silence() {
   fi
 }
 
-OPENSSL_VERSION="1.1.1s"
+OPENSSL_VERSION="3.4.0"
 BOOST_VERSION="1.76.0"
 BOOST_VERSION_UNDERSCORED="${BOOST_VERSION//\./_}" # convert from 1.76.0 to 1_76_0
-ZLIB_VERSION="1.2.13"
+ZLIB_VERSION="1.3.1"
 PROTOBUF_VERSION="3.11.4"
-CURL_VERSION="7.86.0"
+CURL_VERSION="8.12.0"
 AWS_SDK_CPP_VERSION="1.11.420"
 
 LIB_OPENSSL="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
-LIB_BOOST="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"
+LIB_BOOST="https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORED}.tar.gz"
 LIB_ZLIB="https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
 LIB_PROTOBUF="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION}.tar.gz"
 LIB_CURL="https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz"
@@ -227,7 +227,7 @@ if [ ! -d "curl-${CURL_VERSION}" ]; then
     sed -Ei .bak 's/#define HAVE_CLOCK_GETTIME_MONOTONIC 1//' lib/curl_config.h
   else
     silence conf --disable-shared --disable-ldap --disable-ldaps --without-libidn2 \
-      --enable-threaded-resolver --disable-debug --without-libssh2 --without-ca-bundle --with-ssl="${INSTALL_DIR}" --without-libidn
+      --enable-threaded-resolver --disable-debug --without-libpsl --without-libssh2 --without-ca-bundle --with-ssl="${INSTALL_DIR}"
   fi
 
   silence make -j

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.22</version>
+            <version>1.1.23</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Upgrade the following dependencies to address CVE violations
- curl 7.86.0 -> 8.12.0
- openssl 1.1.1s -> 3.4.0
- zlib 1.2.13 -> 1.3.1
- schema-registry-serde 1.1.22 -> 1.1.23

Updated third_party lib in `bootstrap` to point to correct folder for certain libraries as part of openssl upgrade. Fix `boost` url as that link is dead now. Tested by successfully running `bootstrap`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
