### PR TITLE
Adding a feature flag (default enabled) to enable/disable oldest future tracking feature

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducer.java
@@ -97,7 +97,7 @@ public class KinesisProducer implements IKinesisProducer {
     private final AtomicLong totalFutureTimeouts = new AtomicLong(0);
     private final GlueSchemaRegistrySerializerInstance glueSchemaRegistrySerializerInstance = new GlueSchemaRegistrySerializerInstance();
     private final Map<Long, SettableFutureTracker> futures = new ConcurrentHashMap<>();
-    private final PriorityBlockingQueue<SettableFutureTracker> oldestFutureTrackerHeap = new PriorityBlockingQueue
+    private final PriorityBlockingQueue<SettableFutureTracker> oldestFutureTrackerHeap = new PriorityBlockingQueue<>
             (10, new SettableFutureTrackerComparator());
     private final ScheduledThreadPoolExecutor futureTimeoutExecutor = new ScheduledThreadPoolExecutor(1,
             new ThreadFactoryBuilder()
@@ -202,7 +202,9 @@ public class KinesisProducer implements IKinesisProducer {
                 });
             }
             futures.clear();
-            oldestFutureTrackerHeap.clear();
+            if (config.getEnableOldestFutureTracker()) {
+                oldestFutureTrackerHeap.clear();
+            }
 
             if (processFailureBehavior == ProcessFailureBehavior.AutoRestart && !destroyed) {
                 log.info("Restarting native producer process.");
@@ -270,7 +272,9 @@ public class KinesisProducer implements IKinesisProducer {
             log.error(message);
             throw new RuntimeException(message);
         }
-        oldestFutureTrackerHeap.remove(futureTracker);
+        if (config.getEnableOldestFutureTracker()) {
+            oldestFutureTrackerHeap.remove(futureTracker);
+        }
         return futureTracker;
     }
     
@@ -294,6 +298,15 @@ public class KinesisProducer implements IKinesisProducer {
      */
     public KinesisProducer(KinesisProducerConfiguration config) {
         this.config = config;
+        env = initEnv();
+        child = new Daemon(pathToExecutable, new MessageHandler(), pathToTmpDir, config, env);
+
+        // We set the policy for the executor service to remove queued tasks if they are cancelled to relieve
+        // unwanted cpu load.
+        futureTimeoutExecutor.setRemoveOnCancelPolicy(true);
+    }
+
+    private Map<String, String> initEnv() {
         String caPath = config.getCaCertPath();
         String caFile = config.getCaCertFile();
         String caDirectory = extractBinaries();
@@ -303,18 +316,23 @@ public class KinesisProducer implements IKinesisProducer {
             caDirectory = caPath;
         }
 
-        env = new ImmutableMap.Builder<String, String>()
+        Map<String, String> env = new ImmutableMap.Builder<String, String>()
                 .put("LD_LIBRARY_PATH", pathToLibDir)
                 .put("DYLD_LIBRARY_PATH", pathToLibDir)
                 .put("CA_DIR", caDirectory)
                 .put("CA_FILE", caFile)
                 .build();
+        return env;
+    }
+
+    KinesisProducer(KinesisProducerConfiguration config, Daemon daemon) {
+        this.config = config;
+        this.child = daemon;
+        this.env = initEnv();
 
         // We set the policy for the executor service to remove queued tasks if they are cancelled to relieve
         // unwanted cpu load.
         futureTimeoutExecutor.setRemoveOnCancelPolicy(true);
-
-        child = new Daemon(pathToExecutable, new MessageHandler(), pathToTmpDir, config, env);
     }
     
     /**
@@ -610,7 +628,9 @@ public class KinesisProducer implements IKinesisProducer {
         }
         SettableFutureTracker futuresTracking = new SettableFutureTracker(f, Instant.now(), Optional.ofNullable(task));
         futures.put(id, futuresTracking);
-        oldestFutureTrackerHeap.add(futuresTracking);
+        if (config.getEnableOldestFutureTracker()) {
+            oldestFutureTrackerHeap.add(futuresTracking);
+        }
         
         PutRecord.Builder pr = PutRecord.newBuilder()
                 .setStreamName(stream)
@@ -670,7 +690,7 @@ public class KinesisProducer implements IKinesisProducer {
      * that have not finished. This returns 0 if there are no pending records in processing state.
      *
      * @return The time in millis since the oldest record is pending to be sent to kinesis endpoint. Returns 0 if
-     * there are no records in processing state.
+     * there are no records in processing state or if enableOldestFutureTracker is set to false.
      */
     @Override
     public long getOldestRecordTimeInMillis() {

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
@@ -389,6 +389,7 @@ public class KinesisProducerConfiguration {
     private String caCertFile = "";
     private String glueSchemaRegistryPropertiesFilePath = "";
     private long userRecordTimeoutInMillis = 0;
+    private boolean enableOldestFutureTracker = true; // default on
 
     /**
      * Enable aggregation. With aggregation, multiple user records are packed into a single
@@ -957,6 +958,19 @@ public class KinesisProducerConfiguration {
      */
     public long getUserRecordTimeoutInMillis() {
         return userRecordTimeoutInMillis;
+    }
+
+    /**
+     * Returns whether tracking of the oldest outstanding future is enabled.
+     *
+     * <p>
+     * When enabled, the KPL will track the oldest outstanding future that hasn't been
+     * completed. This can be useful for monitoring purposes but may have a performance impact.
+     *
+     * @return true if oldest future tracking is enabled, false otherwise
+     */
+    public boolean getEnableOldestFutureTracker() {
+        return enableOldestFutureTracker;
     }
 
     /**
@@ -1669,6 +1683,21 @@ public class KinesisProducerConfiguration {
         }
         this.userRecordTimeoutInMillis = userRecordTimeoutInMillis;
         return this;
+    }
+
+    /**
+     * Sets whether to enable tracking of the oldest outstanding future.
+     *
+     * <p>
+     * When enabled, the KPL will track the oldest outstanding future that hasn't been
+     * completed. This can be useful for monitoring purposes but might have a performance impact.
+     *
+     * @param enableOldestFutureTracker true to enable oldest future tracking, false to disable (default true)
+     * @return this {@link KinesisProducerConfiguration} instance
+     */
+    public KinesisProducerConfiguration setEnableOldestFutureTracker(boolean enableOldestFutureTracker) {
+       this.enableOldestFutureTracker = enableOldestFutureTracker;
+       return this;
     }
 
     protected Message toProtobufMessage() {

--- a/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 import org.mockserver.socket.PortFactory;
@@ -31,6 +32,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -263,6 +265,18 @@ public class KinesisProducerTest {
         }
     }
 
+    private KinesisProducer getProducer(KinesisProducerConfiguration cfg, Daemon daemon,
+                                        AwsCredentialsProvider provider,
+                                        AwsCredentialsProvider metrics_creds_provider) {
+        if (provider != null) {
+            cfg.setCredentialsProvider(provider);
+        }
+        if (metrics_creds_provider != null) {
+            cfg.setMetricsCredentialsProvider(metrics_creds_provider);
+        }
+        return new KinesisProducer(cfg, daemon);
+    }
+
     private KinesisProducer getProducer(AwsCredentialsProvider provider, AwsCredentialsProvider metrics_creds_provider) {
         final KinesisProducerConfiguration cfg = new KinesisProducerConfiguration()
                 .setKinesisEndpoint("localhost")
@@ -298,5 +312,77 @@ public class KinesisProducerTest {
 
         // Then we expect it to return 0.
         assertEquals(0L, actual);
+    }
+
+    @Test
+    public void getOldestRecord_ReturnsPendingOldestRecord() {
+        // given
+        final KinesisProducerConfiguration cfg = new KinesisProducerConfiguration()
+                .setKinesisEndpoint("localhost")
+                .setKinesisPort(port)
+                .setCloudwatchEndpoint("localhost")
+                .setCloudwatchPort(port)
+                .setStsEndpoint("localhost")
+                .setStsPort(sts_port)
+                .setVerifyCertificate(false)
+                .setAggregationEnabled(false)
+                .setCredentialsRefreshDelay(100)
+                .setRegion("us-west-1")
+                .setRecordTtl(200)
+                .setMetricsUploadDelay(100)
+                .setRecordTtl(100)
+                .setLogLevel("warning")
+                .setEnableOldestFutureTracker(true); // oldest future tracker is enabled
+        Daemon child = Mockito.mock(Daemon.class);
+        IKinesisProducer candidate = getProducer(cfg, child, null, null);
+
+        // when
+        candidate.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
+        sleep(2000);
+        candidate.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
+
+        // then
+        assertTrue(candidate.getOldestRecordTimeInMillis() > 0);
+        assertEquals(2, candidate.getOutstandingRecordsCount());
+    }
+
+    @Test
+    public void getOldestRecordTime_ShouldReturn0_WhenConfigIsDisabled() {
+        // given
+        final KinesisProducerConfiguration cfg = new KinesisProducerConfiguration()
+                .setKinesisEndpoint("localhost")
+                .setKinesisPort(port)
+                .setCloudwatchEndpoint("localhost")
+                .setCloudwatchPort(port)
+                .setStsEndpoint("localhost")
+                .setStsPort(sts_port)
+                .setVerifyCertificate(false)
+                .setAggregationEnabled(false)
+                .setCredentialsRefreshDelay(100)
+                .setRegion("us-west-1")
+                .setRecordTtl(200)
+                .setMetricsUploadDelay(100)
+                .setRecordTtl(100)
+                .setLogLevel("warning")
+                .setEnableOldestFutureTracker(false); // oldest future tracker is disabled
+        Daemon child = Mockito.mock(Daemon.class);
+        IKinesisProducer candidate = getProducer(cfg, child, null, null);
+
+        // when
+        candidate.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
+        sleep(2000);
+        candidate.addUserRecord("streamName", "partitionKey", ByteBuffer.wrap(new byte[0]));
+
+        // then
+        assertEquals(0, candidate.getOldestRecordTimeInMillis());
+        assertEquals(2, candidate.getOutstandingRecordsCount());
+    }
+
+    private void sleep(long millisToSleep) {
+        try {
+            Thread.sleep(millisToSleep);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
We use 0.14.2 of the library. When we upgraded to any version beyond 0.14.2, we saw a significant drop in throughput of the records that we were able to send to KPL. 

We've narrowed this down to the oldestFutureTracker feature that was introduced in 0.14.3. We disabled the feature in 0.14.3 and then saw back to normal throughput. 

The current understanding is that the PriorityQueue starts off at a size of 10 items, but then grows which involves a lot of copying / moving etc. 

This PR introduces a flag to control enabling/disabling this oldest future tracking feature. 




![variousVersions](https://github.com/user-attachments/assets/2dd0136d-d758-4933-9d1b-f6990f0fd301)

Note how 0.14.2 and 0.14.3-wo-heap don't impact the time we spend in KPL. 