### PR TITLE
Fix metrics upload race condition

### DIFF
--- a/aws/metrics/accumulator.h
+++ b/aws/metrics/accumulator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright 2025 Amazon.com, Inc. or its affiliates.
  * Licensed under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
@@ -16,7 +16,6 @@
 #ifndef AWS_METRICS_ACCUMULATOR_H_
 #define AWS_METRICS_ACCUMULATOR_H_
 
-#include <chrono>
 #include <list>
 
 #include <boost/accumulators/accumulators.hpp>
@@ -27,6 +26,7 @@
 #include <boost/accumulators/statistics/sum.hpp>
 #include <boost/accumulators/statistics/count.hpp>
 
+#include <aws/metrics/metrics_header.h>
 #include <aws/utils/logging.h>
 
 #include <aws/mutex.h>
@@ -34,9 +34,6 @@
 // Bucketed time-series accumulator modeled after CloudWatch metrics/statistics.
 namespace aws {
 namespace metrics {
-
-using Clock = std::chrono::steady_clock;
-using TimePoint = Clock::time_point;
 
 namespace detail {
 
@@ -71,7 +68,7 @@ template <typename ValType,
 class AccumulatorList {
  public:
   void operator()(ValType val) {
-    auto tp = TimePoint(buckets_since_epoch());
+    auto tp = current_time();
 
     {
       ReadLock lk(mutex_);
@@ -82,10 +79,6 @@ class AccumulatorList {
     }
 
     WriteLock lk(mutex_);
-    while (!accums_.empty() &&
-           buckets_between(accums_.front().first, tp) > NumBuckets) {
-      accums_.pop_front();
-    }
     if (accums_.empty() || accums_.back().first < tp) {
       accums_.emplace_back(std::piecewise_construct,
                            std::forward_as_tuple(tp),
@@ -100,21 +93,32 @@ class AccumulatorList {
       return 0;
     }
 
-    auto cutoff = TimePoint(buckets_since_epoch() - BucketSize(buckets));
+    auto r = range(buckets);
+    return get<Stat>(r.first, r.second);
+  }
 
+  template <typename Stat>
+  ValType get(TimePoint begin, TimePoint end) {
     ReadLock lk(mutex_);
 
     if (std::is_same<Stat, boost::accumulators::tag::count>::value ||
         std::is_same<Stat, boost::accumulators::tag::sum>::value) {
-      return this->sum<Stat>(cutoff);
+      return this->sum<Stat>(begin, end);
     } else if (std::is_same<Stat, boost::accumulators::tag::mean>::value) {
       return
-          this->sum<boost::accumulators::tag::sum>(cutoff) /
-              this->sum<boost::accumulators::tag::count>(cutoff);
+          this->sum<boost::accumulators::tag::sum>(begin, end) /
+              this->sum<boost::accumulators::tag::count>(begin, end);
     } else {
       return
           boost::accumulators::extract_result<Stat>(
-              combine<OneStatAccum<Stat>, Stat>(cutoff));
+              combine<OneStatAccum<Stat>, Stat>(begin, end));
+    }
+  }
+
+  void flush(TimePoint checkpoint) {
+    WriteLock lk(mutex_);
+    while (!accums_.empty() && accums_.front().first <= checkpoint) {
+      accums_.pop_front();
     }
   }
 
@@ -124,6 +128,18 @@ class AccumulatorList {
       boost::accumulators::accumulator_set<
           ValType,
           boost::accumulators::stats<Stat>>;
+
+  static inline std::pair<TimePoint, TimePoint> range(size_t buckets) {
+    return range(buckets, current_time());
+  }
+
+  static inline std::pair<TimePoint, TimePoint> range(size_t buckets, TimePoint end) {
+    return std::pair<TimePoint, TimePoint>(end - BucketSize(buckets), end);
+  }
+
+  static inline TimePoint current_time() {
+    return TimePoint(buckets_since_epoch());
+  }
 
   static inline BucketSize buckets_since_epoch() {
     return std::chrono::duration_cast<BucketSize>(
@@ -136,10 +152,10 @@ class AccumulatorList {
   }
 
   template <typename CombiningAccumType, typename Stat>
-  CombiningAccumType combine(TimePoint cutoff) {
+  CombiningAccumType combine(TimePoint begin, TimePoint end) {
     CombiningAccumType a;
     for (auto& p : accums_) {
-      if (p.first > cutoff) {
+      if (p.first > begin && p.first <= end) {
         a(p.second.template get<Stat>());
       }
     }
@@ -147,9 +163,9 @@ class AccumulatorList {
   }
 
   template <typename Stat>
-  ValType sum(TimePoint cutoff) {
+  ValType sum(TimePoint begin, TimePoint end) {
     return boost::accumulators::sum(
-        combine<OneStatAccum<boost::accumulators::tag::sum>, Stat>(cutoff));
+        combine<OneStatAccum<boost::accumulators::tag::sum>, Stat>(begin, end));
   }
 
   Mutex mutex_;
@@ -191,6 +207,30 @@ class AccumulatorImpl {
     return get<boost::accumulators::tag::sum>(buckets);
   }
 
+  ValType count(TimePoint begin, TimePoint end) {
+    return get<boost::accumulators::tag::count>(begin, end);
+  }
+
+  ValType mean(TimePoint begin, TimePoint end) {
+    return get<boost::accumulators::tag::mean>(begin, end);
+  }
+
+  ValType min(TimePoint begin, TimePoint end) {
+    return get<boost::accumulators::tag::min>(begin, end);
+  }
+
+  ValType max(TimePoint begin, TimePoint end) {
+    return get<boost::accumulators::tag::max>(begin, end);
+  }
+
+  ValType sum(TimePoint begin, TimePoint end) {
+    return get<boost::accumulators::tag::sum>(begin, end);
+  }
+
+  void flush(TimePoint checkpoint) {
+    accums_.flush(checkpoint);
+  }
+
   TimePoint start_time() const noexcept {
     return start_time_;
   }
@@ -219,6 +259,11 @@ class AccumulatorImpl {
     } else {
       return overall_.template get<Stat>();
     }
+  }
+
+  template <typename Stat>
+  ValType get(TimePoint begin, TimePoint end) {
+    return accums_.template get<Stat>(begin, end);
   }
 
   detail::AccumulatorList<ValType, Accum, BucketSize, NumBuckets> accums_;

--- a/aws/metrics/metrics_header.h
+++ b/aws/metrics/metrics_header.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AWS_METRICS_METRICS_HEADER_H
+#define AWS_METRICS_METRICS_HEADER_H
+
+#include <chrono>
+
+namespace aws {
+namespace metrics {
+
+using Clock = std::chrono::steady_clock;
+using TimePoint = Clock::time_point;
+
+} // namespace metrics
+} // namespace aws
+
+#endif //AWS_METRICS_METRICS_HEADER_H

--- a/aws/metrics/metrics_manager.cc
+++ b/aws/metrics/metrics_manager.cc
@@ -96,6 +96,8 @@ void MetricsManager::upload() {
   TimePoint begin = upload_checkpoint_;
   TimePoint end = Clock::now() - std::chrono::seconds(1);
 
+  upload_checkpoint_ = end;
+
   for (auto& m : metrics_index_.get_all()) {
     if (constants::filter(m->all_dimensions(), level_, granularity_) &&
         m->accumulator().count(begin, end) > 0) {
@@ -137,12 +139,10 @@ void MetricsManager::upload() {
       }
       break;
     }
+  }
 
-    for (auto& m : uploads) {
-      m->accumulator().flush(end);
-    }
-
-    upload_checkpoint_ = end;
+  for (auto& m : uploads) {
+    m->accumulator().flush(end);
   }
 }
 

--- a/aws/metrics/metrics_manager.h
+++ b/aws/metrics/metrics_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright 2025 Amazon.com, Inc. or its affiliates.
  * Licensed under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
@@ -25,6 +25,7 @@
 #include <aws/metrics/metric.h>
 #include <aws/metrics/metrics_constants.h>
 #include <aws/metrics/metrics_finder.h>
+#include <aws/metrics/metrics_header.h>
 #include <aws/metrics/metrics_index.h>
 #include <aws/monitoring/CloudWatchClient.h>
 #include <aws/utils/executor.h>
@@ -110,9 +111,9 @@ class MetricsFinderBuilder {
 
 struct UploadContext : public Aws::Client::AsyncCallerContext {
   UploadContext() :
-      created(std::chrono::steady_clock::now()),
+      created(Clock::now()),
       attempts(0) {}
-  std::chrono::steady_clock::time_point created;
+  TimePoint created;
   size_t attempts;
 };
 
@@ -146,6 +147,8 @@ class MetricsManager {
           std::move(std::get<0>(t)),
           std::move(std::get<1>(t)));
     }
+
+    upload_checkpoint_ = TimePoint::min();
 
     scheduled_upload_ =
         executor_->schedule(
@@ -201,6 +204,7 @@ class MetricsManager {
   MetricsIndex metrics_index_;
 
   std::shared_ptr<aws::utils::ScheduledCallback> scheduled_upload_;
+  TimePoint upload_checkpoint_;
 };
 
 class NullMetricsManager : public MetricsManager {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-producer/issues/188

*Description of changes:* Fixes a race condition between the metrics manager and the metrics accumulator that could cause missed data points. If these were the only data points in the last 60 seconds, this could cause CloudWatch to fail the PutMetricData request as it would try to upload the default values in C++ Boost accumulators.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
