### PR TITLE
Allow coredumps to be disabled

### DIFF
--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -19,6 +19,7 @@
 #include <regex>
 
 #include <boost/noncopyable.hpp>
+#include <boost/optional.hpp>
 
 #include <aws/kinesis/protobuf/messages.pb.h>
 
@@ -135,13 +136,19 @@ class Configuration : private boost::noncopyable {
   // the soft limit is already at or above the target amount, it is not
   // changed.
   //
+  // If set to false, the core file size soft limit is explicitly set to 0 to
+  // disable core dumps.
+  //
+  // If unset, the process leaves the core file size limit unchanged, using
+  // the system or environment default.
+  //
   // Note that even if the limit is successfully raised (or already
   // sufficient), it does not guarantee that core files will be written on a
   // crash, since that is dependent on operation system settings that's beyond
   // the control of individual processes.
   //
-  // Default: false
-  bool enable_core_dumps() const noexcept {
+  // Default: unset
+  boost::optional<bool> enable_core_dumps() const noexcept {
     return enable_core_dumps_;
   }
 
@@ -613,12 +620,18 @@ class Configuration : private boost::noncopyable {
   // the soft limit is already at or above the target amount, it is not
   // changed.
   //
+  // If set to false, the core file size soft limit is explicitly set to 0 to
+  // disable core dumps.
+  //
+  // If unset, the process leaves the core file size limit unchanged, using
+  // the system or environment default.
+  //
   // Note that even if the limit is successfully raised (or already
   // sufficient), it does not guarantee that core files will be written on a
   // crash, since that is dependent on operation system settings that's beyond
   // the control of individual processes.
   //
-  // Default: false
+  // Default: unset
   Configuration& enable_core_dumps(bool val) {
     enable_core_dumps_ = val;
     return *this;
@@ -1114,7 +1127,9 @@ class Configuration : private boost::noncopyable {
     collection_max_count(c.collection_max_count());
     collection_max_size(c.collection_max_size());
     connect_timeout(c.connect_timeout());
-    enable_core_dumps(c.enable_core_dumps());
+    if (c.has_enable_core_dumps()) {
+      enable_core_dumps(c.enable_core_dumps());
+    }
     fail_if_throttled(c.fail_if_throttled());
     kinesis_endpoint(c.kinesis_endpoint());
     kinesis_port(c.kinesis_port());
@@ -1162,7 +1177,7 @@ class Configuration : private boost::noncopyable {
   size_t collection_max_count_ = 500;
   size_t collection_max_size_ = 5242880;
   uint64_t connect_timeout_ = 6000;
-  bool enable_core_dumps_ = false;
+  boost::optional<bool> enable_core_dumps_;
   bool fail_if_throttled_ = false;
   std::string kinesis_endpoint_ = "";
   size_t kinesis_port_ = 443;

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
@@ -358,7 +358,7 @@ public class KinesisProducerConfiguration {
     private long collectionMaxSize = 5242880L;
     private long connectTimeout = 6000L;
     private long credentialsRefreshDelay = 5000L;
-    private boolean enableCoreDumps = false;
+    private Boolean enableCoreDumps = null;
     private boolean failIfThrottled = false;
     private String kinesisEndpoint = "";
     private long kinesisPort = 443L;
@@ -530,16 +530,21 @@ public class KinesisProducerConfiguration {
      * If set to true, the KPL native process will attempt to raise its own core file size soft
      * limit to 128MB, or the hard limit, whichever is lower. If the soft limit is already at or
      * above the target amount, it is not changed.
-     * 
+     * <p>
+     * If set to false, the core file size soft limit is explicitly set to 0 to disable core dumps.
+     * <p>
+     * If unset, the process leaves the core file size limit unchanged, using the system or
+     * environment default.
+     *
      * <p>
      * Note that even if the limit is successfully raised (or already sufficient), it does not
      * guarantee that core files will be written on a crash, since that is dependent on operation
      * system settings that's beyond the control of individual processes.
-     * 
-     * <p><b>Default</b>: false
+     *
+     * <p><b>Default</b>: unset
      */
     public boolean isEnableCoreDumps() {
-      return enableCoreDumps;
+      return enableCoreDumps != null ? enableCoreDumps : false;
     }
 
     /**
@@ -1140,12 +1145,17 @@ public class KinesisProducerConfiguration {
 
     /**
      * This has no effect on Windows.
-     * 
+     *
      * <p>
      * If set to true, the KPL native process will attempt to raise its own core file size soft
      * limit to 128MB, or the hard limit, whichever is lower. If the soft limit is already at or
      * above the target amount, it is not changed.
-     * 
+     * <p>
+     * If set to false, the core file size soft limit is explicitly set to 0 to disable core dumps.
+     * <p>
+     * If unset, the process leaves the core file size limit unchanged, using the system or
+     * environment default.
+     *
      * <p>
      * Note that even if the limit is successfully raised (or already sufficient), it does not
      * guarantee that core files will be written on a crash, since that is dependent on operation
@@ -1711,7 +1721,6 @@ public class KinesisProducerConfiguration {
                 .setCollectionMaxCount(collectionMaxCount)
                 .setCollectionMaxSize(collectionMaxSize)
                 .setConnectTimeout(connectTimeout)
-                .setEnableCoreDumps(enableCoreDumps)
                 .setFailIfThrottled(failIfThrottled)
                 .setKinesisEndpoint(kinesisEndpoint)
                 .setKinesisPort(kinesisPort)
@@ -1739,7 +1748,9 @@ public class KinesisProducerConfiguration {
         if (threadPoolSize > 0) {
             builder = builder.setThreadPoolSize(threadPoolSize);
         }
-
+        if (enableCoreDumps != null) {
+            builder = builder.setEnableCoreDumps(enableCoreDumps);
+        }
         Configuration c = this.additionalConfigsToProtobuf(builder).build();
         return Message.newBuilder().setConfiguration(c).setId(0).build();
     }


### PR DESCRIPTION
*Description of changes:*
When enableCoredumps is false, set core file size limits to zero so no core dump is generated to make coredump generation controllable. When unset, default to environment default  

```
[kpl-daemon-0003] INFO software.amazon.kinesis.producer.LogInputStreamReader - [2025-07-25 08:19:53.040517] [0x00054aef][0x00007f4997059240] [info] [main.cc:334] Disabling core dumps: Current soft limit is 18446744073709551615; hard limit is 18446744073709551615; setting soft limit to 0
```

Updated code to abort() after core dump limit is set and tested three scenarios
1. unset - core dump file generated 
2. false - not generated 
3. true - generated 

Also, run the code without the abort() and code execute without issue
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
