### PR TITLE
Add UserRecord in UserRecordResult to allow customers to retrieve UserRecord in callbacks

### DIFF
--- a/aws/kinesis/core/user_record.cc
+++ b/aws/kinesis/core/user_record.cc
@@ -55,6 +55,13 @@ aws::kinesis::protobuf::Message UserRecord::to_put_record_result() {
   auto prr = m.mutable_put_record_result();
   prr->set_success(false);
 
+  prr->set_stream_name(std::move(stream_));
+  prr->set_partition_key(std::move(partition_key_));
+  if (has_explicit_hash_key_) {
+    prr->set_explicit_hash_key(std::move(hash_key_.str()));
+  }
+  prr->set_data(std::move(data_));
+
   for (size_t i = 0; i < attempts_.size(); i++) {
     auto a = prr->add_attempts();
     auto delay = (i == 0)

--- a/aws/kinesis/protobuf/messages.proto
+++ b/aws/kinesis/protobuf/messages.proto
@@ -57,10 +57,14 @@ message Attempt {
 }
 
 message PutRecordResult {
-  repeated Attempt attempts        = 1;
-  required bool    success         = 2;
-  optional string  shard_id        = 3;
-  optional string  sequence_number = 4;
+  repeated Attempt attempts          = 1;
+  required bool    success           = 2;
+  optional string  shard_id          = 3;
+  optional string  sequence_number   = 4;
+  optional string  stream_name       = 5;
+  optional string  partition_key     = 6;
+  optional string  explicit_hash_key = 7;
+  optional bytes   data              = 8;
 }
 
 // *********** Credentials ************

--- a/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducer.java
+++ b/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducer.java
@@ -16,6 +16,7 @@
 package software.amazon.kinesis.producer.sample;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import software.amazon.kinesis.producer.Attempt;
 import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.UserRecord;
 import software.amazon.kinesis.producer.UserRecordFailedException;
 import software.amazon.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
@@ -99,15 +101,18 @@ public class SampleProducer {
                 if (t instanceof UserRecordFailedException) {
                     int attempts = ((UserRecordFailedException) t).getResult().getAttempts().size()-1;
                     Attempt last = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts);
+                    UserRecord userRecord = ((UserRecordFailedException) t).getResult().getUserRecord();
+                    String data = StandardCharsets.UTF_8.decode(userRecord.getData()).toString();
                     if(attempts > 1) {
                         Attempt previous = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts - 1);
                         log.error(String.format(
-                                "Record failed to put - %s : %s. Previous failure - %s : %s",
-                                last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(), previous.getErrorMessage()));
-                    }else{
+                                "UserRecord %s with data %s failed to put - %s : %s. Previous failure - %s : %s",
+                                userRecord, data, last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(),
+                                previous.getErrorMessage()));
+                    } else{
                         log.error(String.format(
-                                "Record failed to put - %s : %s.",
-                                last.getErrorCode(), last.getErrorMessage()));
+                                "UserRecord %s with data %s failed to put - %s : %s.",
+                                userRecord, data, last.getErrorCode(), last.getErrorMessage()));
                     }
 
                 } else if (t instanceof UnexpectedMessageException) {
@@ -120,6 +125,10 @@ public class SampleProducer {
             @Override
             public void onSuccess(UserRecordResult result) {
                 completed.getAndIncrement();
+
+                UserRecord userRecord = result.getUserRecord();
+                log.info(String.format("Successfully put UserRecord %s with data %s", userRecord,
+                        StandardCharsets.UTF_8.decode(userRecord.getData()).toString()));
             }
         };
         

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecord.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecord.java
@@ -4,6 +4,9 @@ import com.amazonaws.services.schemaregistry.common.Schema;
 
 import java.nio.ByteBuffer;
 
+import lombok.ToString;
+
+@ToString
 public class UserRecord {
     /**
      * Stream to put to.

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordResult.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordResult.java
@@ -35,11 +35,21 @@ public class UserRecordResult {
     private String sequenceNumber;
     private String shardId;
     private boolean successful;
+    private UserRecord userRecord;
     
     public UserRecordResult(List<Attempt> attempts, String sequenceNumber, String shardId, boolean successful) {
         this.attempts = attempts;
         this.sequenceNumber = sequenceNumber;
         this.shardId = shardId;
+        this.successful = successful;
+    }
+
+    public UserRecordResult(List<Attempt> attempts, String sequenceNumber, String shardId, UserRecord userRecord,
+            boolean successful) {
+        this.attempts = attempts;
+        this.sequenceNumber = sequenceNumber;
+        this.shardId = shardId;
+        this.userRecord = userRecord;
         this.successful = successful;
     }
     
@@ -78,6 +88,14 @@ public class UserRecordResult {
     public boolean isSuccessful() {
         return successful;
     }
+
+    /**
+     *
+     * @return The UserRecord that was attempted to be put
+     */
+    public UserRecord getUserRecord() {
+        return userRecord;
+    }
     
     protected static UserRecordResult fromProtobufMessage(Messages.PutRecordResult r) {
         final List<Attempt> attempts = new ArrayList<>(r.getAttemptsCount());
@@ -88,6 +106,8 @@ public class UserRecordResult {
                 new ImmutableList.Builder<Attempt>().addAll(attempts).build(),
                 r.hasSequenceNumber() ? r.getSequenceNumber() : null,
                 r.hasShardId() ? r.getShardId() : null,
+                r.hasData() ? new UserRecord(r.getStreamName(), r.getPartitionKey(), r.getExplicitHashKey(),
+                        r.getData().asReadOnlyByteBuffer()) : null,
                 r.getSuccess());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#76

*Description of changes:*
Adds the `UserRecord` in the `UserRecordResult` so that the data and other relevant PutRecord information can be retrieved in `onSuccess` and `onFailure` callbacks

*Testing:*
Ran SampleProducer

`onSuccess`
```
[pool-6-thread-150] INFO software.amazon.kinesis.producer.sample.SampleProducer - Successfully put UserRecord UserRecord(streamName=kpltest, streamARN=null, partitionKey=1753482510482, explicitHashKey=37836790953609139420823924948284851877, data=java.nio.HeapByteBufferR[pos=128 lim=128 cap=128], schema=null) with data 1879 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

Induced a `ResourceNotFound` to test `onFailure`
```
[pool-6-thread-289] ERROR software.amazon.kinesis.producer.sample.SampleProducer - UserRecord UserRecord(streamName=kpltest, streamARN=null, partitionKey=1753482546126, explicitHashKey=145514194416976864704373545402421673781, data=java.nio.HeapByteBufferR[pos=128 lim=128 cap=128], schema=null) with data 1999 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa failed to put - Expired : Record 1999 has reached expiration. Previous failure - ResourceNotFoundException : Stream kpltest under account 705755217893 not found.
[pool-6-thread-289] ERROR software.amazon.kinesis.producer.sample.SampleProducer - Exception during put
software.amazon.kinesis.producer.UserRecordFailedException
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler.onPutRecordResult(KinesisProducer.java:242)
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler.access$100(KinesisProducer.java:165)
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler$1.run(KinesisProducer.java:172)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
