### PR TITLE
Add ability for users to fetch the UserRecord in onSuccess and onFailure

### DIFF
--- a/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducer.java
+++ b/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducer.java
@@ -16,6 +16,7 @@
 package software.amazon.kinesis.producer.sample;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 import software.amazon.kinesis.producer.Attempt;
 import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.UserRecord;
+import software.amazon.kinesis.producer.KinesisProducerException;
 import software.amazon.kinesis.producer.UserRecordFailedException;
 import software.amazon.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
@@ -96,23 +99,28 @@ public class SampleProducer {
             @Override
             public void onFailure(Throwable t) {
                 // If we see any failures, we will log them.
-                if (t instanceof UserRecordFailedException) {
-                    int attempts = ((UserRecordFailedException) t).getResult().getAttempts().size()-1;
-                    Attempt last = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts);
-                    if(attempts > 1) {
-                        Attempt previous = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts - 1);
-                        log.error(String.format(
-                                "Record failed to put - %s : %s. Previous failure - %s : %s",
-                                last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(), previous.getErrorMessage()));
-                    }else{
-                        log.error(String.format(
-                                "Record failed to put - %s : %s.",
-                                last.getErrorCode(), last.getErrorMessage()));
-                    }
+                if (t instanceof KinesisProducerException) {
+                    UserRecord userRecord = ((KinesisProducerException) t).getUserRecord();
+                    String data = StandardCharsets.UTF_8.decode(userRecord.getData()).toString();
+                    if (t instanceof UserRecordFailedException) {
+                        int attempts = ((UserRecordFailedException) t).getResult().getAttempts().size()-1;
+                        Attempt last = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts);
+                        if(attempts > 1) {
+                            Attempt previous = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts - 1);
+                            log.error(String.format(
+                                    "UserRecord %s with data %s failed to put - %s : %s. Previous failure - %s : %s",
+                                    userRecord, data, last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(),
+                                    previous.getErrorMessage()));
+                        } else{
+                            log.error(String.format(
+                                    "UserRecord %s with data %s failed to put - %s : %s.",
+                                    userRecord, data, last.getErrorCode(), last.getErrorMessage()));
+                        }
 
-                } else if (t instanceof UnexpectedMessageException) {
-                    log.error("Record failed to put due to unexpected message received from native layer",
-                            t);
+                    } else {
+                        log.error(String.format("UserRecord %s with data %s failed to put with unexpected error: ",
+                                userRecord, data), t);
+                    }
                 }
                 log.error("Exception during put", t);
             }
@@ -120,6 +128,10 @@ public class SampleProducer {
             @Override
             public void onSuccess(UserRecordResult result) {
                 completed.getAndIncrement();
+
+                UserRecord userRecord = result.getUserRecord();
+                log.info(String.format("Successfully put UserRecord %s with data %s", userRecord,
+                        StandardCharsets.UTF_8.decode(userRecord.getData()).toString()));
             }
         };
         

--- a/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducerConfig.java
+++ b/java/amazon-kinesis-producer-sample/src/software/amazon/kinesis/producer/sample/SampleProducerConfig.java
@@ -213,6 +213,10 @@ public class SampleProducerConfig {
         // on each each set method for details.
         KinesisProducerConfiguration config = new KinesisProducerConfiguration();
 
+        // Stores the UserRecord associated with an addUserRecord call in the future. The UserRecord
+        // will be returned in the exception or UserRecordResult.
+        config.setReturnUserRecordInFuture(true);
+
         // You can also load config from file. A sample properties file is
         // included in the project folder.
         // KinesisProducerConfiguration config =

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/FutureTimedOutException.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/FutureTimedOutException.java
@@ -15,11 +15,15 @@ package software.amazon.kinesis.producer;
  * limitations under the License.
  */
 
-public class FutureTimedOutException extends Exception {
+/**
+ * The exception thrown when a UserRecord reaches the
+ * {@link KinesisProducerConfiguration#setUserRecordTimeoutInMillis(long)} timeout without being put into Kinesis.
+ */
+public class FutureTimedOutException extends KinesisProducerException {
     private static final long serialVersionUID = 3168271192277927600L;
 
-    public FutureTimedOutException(String message) {
-        super(message);
+    public FutureTimedOutException(String message, UserRecord userRecord) {
+        super(message, userRecord);
     }
 }
 

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
@@ -390,6 +390,7 @@ public class KinesisProducerConfiguration {
     private String glueSchemaRegistryPropertiesFilePath = "";
     private long userRecordTimeoutInMillis = 0;
     private boolean enableOldestFutureTracker = true; // default on
+    private boolean returnUserRecordInFuture = false;
 
     /**
      * Enable aggregation. With aggregation, multiple user records are packed into a single
@@ -976,6 +977,22 @@ public class KinesisProducerConfiguration {
      */
     public boolean getEnableOldestFutureTracker() {
         return enableOldestFutureTracker;
+    }
+
+    /**
+     * Returns whether returning UserRecord in Futures is enabled
+     *
+     * <p>
+     * When enabled, the KPL will retain in memory the UserRecord added by
+     * {@link KinesisProducer#addUserRecord(UserRecord)} or any of its overloaded methods and
+     * pass it to the completed Future. This can be useful when you need to do something on completion
+     * of the future but need to know the specific UserRecord associated to that future. Since this retains the
+     * data in memory for longer, enabling this may increase the memory usage of the KPL.
+     *
+     * @return true if returning UserRecord in Futures is enabled, false otherwise
+     */
+    public boolean getReturnUserRecordInFuture() {
+        return returnUserRecordInFuture;
     }
 
     /**
@@ -1708,6 +1725,24 @@ public class KinesisProducerConfiguration {
     public KinesisProducerConfiguration setEnableOldestFutureTracker(boolean enableOldestFutureTracker) {
        this.enableOldestFutureTracker = enableOldestFutureTracker;
        return this;
+    }
+
+    /**
+     * Sets whether returning UserRecord in Futures is enabled
+     *
+     * <p>
+     * When enabled, the KPL will retain in memory the UserRecord added by
+     * {@link KinesisProducer#addUserRecord(UserRecord)} or any of its overloaded methods and
+     * pass it to the completed Future. This can be useful when you need to do something on completion
+     * of the future but need to know the specific UserRecord associated to that future. Since this retains the
+     * data in memory for longer, enabling this may increase the memory usage of the KPL.
+     *
+     * @param returnUserRecordInFuture true to enable returning UserRecord in Futures, false to disable (default false)
+     * @return this {@link KinesisProducerConfiguration} instance
+     */
+    public KinesisProducerConfiguration setReturnUserRecordInFuture(boolean returnUserRecordInFuture) {
+        this.returnUserRecordInFuture = returnUserRecordInFuture;
+        return this;
     }
 
     protected Message toProtobufMessage() {

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerException.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.producer;
+
+/**
+ * This is the wrapper exception thrown and returned to callbacks in onFailure. If
+ * {@link KinesisProducerConfiguration#setReturnUserRecordInFuture(boolean)} is set to true, this will contain
+ * the userRecord associated with the future returned from a {@link KinesisProducer#addUserRecord(UserRecord)}
+ * call or any of its overloaded methods.
+ */
+public class KinesisProducerException extends Exception {
+    private static final long serialVersionUID = 3168271192277927600L;
+
+    /**
+     * If {@link KinesisProducerConfiguration#setReturnUserRecordInFuture(boolean)} is set to true,
+     * this will contain UserRecord associated with this future. If it is false, this will be null.
+     */
+    private UserRecord userRecord;
+
+    public KinesisProducerException(Throwable cause, UserRecord userRecord) {
+        super(cause);
+        this.userRecord = userRecord;
+    }
+
+    public KinesisProducerException(String message, UserRecord userRecord) {
+        super(message);
+        this.userRecord = userRecord;
+    }
+
+    public KinesisProducerException(String message) {
+        super(message);
+    }
+
+    public KinesisProducerException(UserRecord userRecord) {
+        this.userRecord = userRecord;
+    }
+
+    public UserRecord getUserRecord() {
+        return userRecord;
+    }
+
+}

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UnexpectedMessageException.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UnexpectedMessageException.java
@@ -15,11 +15,19 @@
 
 package software.amazon.kinesis.producer;
 
-public class UnexpectedMessageException extends Exception {
+/**
+ * The exception thrown when an unexpected message is read from the native layer.
+ */
+public class UnexpectedMessageException extends KinesisProducerException {
     private static final long serialVersionUID = 3168271192277927600L;
 
     public UnexpectedMessageException(String message) {
         super(message);
     }
+
+    public UnexpectedMessageException(String message, UserRecord userRecord) {
+        super(message, userRecord);
+    }
+
 }
 

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecord.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecord.java
@@ -4,6 +4,9 @@ import com.amazonaws.services.schemaregistry.common.Schema;
 
 import java.nio.ByteBuffer;
 
+import lombok.ToString;
+
+@ToString
 public class UserRecord {
     /**
      * Stream to put to.

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordFailedException.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordFailedException.java
@@ -15,12 +15,20 @@
 
 package software.amazon.kinesis.producer;
 
-public class UserRecordFailedException extends Exception {
+/**
+ * The exception thrown when the max attempts to put a UserRecord into Kinesis is exhausted and the result is not
+ * successful.
+ *
+ * Note: The UserRecord returned from the superclass {@link KinesisProducerException#getUserRecord()} is a reference
+ * to the same object as {@link UserRecordResult#getUserRecord()}.
+ */
+public class UserRecordFailedException extends KinesisProducerException {
     private static final long serialVersionUID = 3168271192277927600L;
 
     private UserRecordResult result;
     
-    public UserRecordFailedException(UserRecordResult result) {
+    public UserRecordFailedException(UserRecordResult result, UserRecord userRecord) {
+        super(userRecord);
         this.result = result;
     }
 

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordResult.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordResult.java
@@ -26,6 +26,10 @@ import com.google.common.collect.ImmutableList;
  * successful, the shard id and sequence number assigned by the backend are
  * provided. A list of {@link Attempt}s is also provided with details about each
  * attempt made.
+ *
+ * If {@link KinesisProducerConfiguration#setReturnUserRecordInFuture(boolean)} is set to true, this will also contain
+ * the userRecord associated with the future returned from a {@link KinesisProducer#addUserRecord(UserRecord)}
+ * call or any of its overloaded methods.
  * 
  * @author chaodeng
  * @see Attempt
@@ -35,6 +39,12 @@ public class UserRecordResult {
     private String sequenceNumber;
     private String shardId;
     private boolean successful;
+
+    /**
+     * If {@link KinesisProducerConfiguration#setReturnUserRecordInFuture(boolean)} is set to true,
+     * this will contain UserRecord associated with this future. If it is false, this will be null.
+     */
+    private UserRecord userRecord;
     
     public UserRecordResult(List<Attempt> attempts, String sequenceNumber, String shardId, boolean successful) {
         this.attempts = attempts;
@@ -77,6 +87,18 @@ public class UserRecordResult {
      */
     public boolean isSuccessful() {
         return successful;
+    }
+
+    /**
+     *
+     * @return The UserRecord that was attempted to be put
+     */
+    public UserRecord getUserRecord() {
+        return userRecord;
+    }
+
+    protected void setUserRecord(UserRecord userRecord) {
+        this.userRecord = userRecord;
     }
     
     protected static UserRecordResult fromProtobufMessage(Messages.PutRecordResult r) {

--- a/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
@@ -15,8 +15,16 @@
 
 package software.amazon.kinesis.producer;
 
+import software.amazon.kinesis.producer.protobuf.Messages.Attempt;
+import software.amazon.kinesis.producer.protobuf.Messages.Message;
+import software.amazon.kinesis.producer.protobuf.Messages.PutRecord;
+import software.amazon.kinesis.producer.protobuf.Messages.PutRecordResult;
 import com.amazonaws.services.schemaregistry.common.Schema;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.ByteString;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -33,17 +41,20 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
 
-import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -51,11 +62,15 @@ import java.util.stream.Stream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doNothing;
 
 public class KinesisProducerTest {
     private static final Logger log = LoggerFactory.getLogger(KinesisProducerTest.class);
@@ -283,7 +298,18 @@ public class KinesisProducerTest {
     }
 
     private KinesisProducer getProducer(AwsCredentialsProvider provider, AwsCredentialsProvider metrics_creds_provider) {
-        final KinesisProducerConfiguration cfg = new KinesisProducerConfiguration()
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration();
+        if (provider != null) {
+            cfg.setCredentialsProvider(provider);
+        }
+        if (metrics_creds_provider != null) {
+            cfg.setMetricsCredentialsProvider(metrics_creds_provider);
+        }
+        return new KinesisProducer(cfg);
+    }
+
+    public KinesisProducerConfiguration buildBasicConfiguration() {
+        return new KinesisProducerConfiguration()
                 .setKinesisEndpoint("localhost")
                 .setKinesisPort(port)
                 .setCloudwatchEndpoint("localhost")
@@ -298,13 +324,6 @@ public class KinesisProducerTest {
                 .setMetricsUploadDelay(100)
                 .setRecordTtl(100)
                 .setLogLevel("warning");
-        if (provider != null) {
-            cfg.setCredentialsProvider(provider);
-        }
-        if (metrics_creds_provider != null) {
-            cfg.setMetricsCredentialsProvider(metrics_creds_provider);
-        }
-        return new KinesisProducer(cfg);
     }
 
     @Test
@@ -489,6 +508,262 @@ public class KinesisProducerTest {
         assertTrue(candidate.getOldestRecordTimeInMillis() > 0);
         assertEquals(2, candidate.getOutstandingRecordsCount()); // we complete the future, but don't remove it from futures hence we still see records
         assertTrue(oldestRecordsInHeap.get());
+    }
+
+    @Test
+    public void addUserRecordReturnsRecordOnSuccess() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration()
+                .setReturnUserRecordInFuture(true);
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes("UTF-8"));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+
+        // Mock a message received from Daemon
+        PutRecordResult prr = PutRecordResult.newBuilder()
+                .setSuccess(true)
+                .setShardId("shard-1")
+                .setSequenceNumber("123")
+                .build();
+        Message m = Message.newBuilder()
+                .setId(new Random().nextLong())
+                .setSourceId(1L) // first message is always 1
+                .setPutRecordResult(prr)
+                .build();
+        producerSpy.getChild().getHandler().onMessage(m);
+
+        // then
+        try {
+            UserRecordResult userRecordResult = f.get(5, TimeUnit.SECONDS);
+            UserRecord userRecord = userRecordResult.getUserRecord();
+            assertEquals(streamName, userRecord.getStreamName());
+            assertEquals(partitionKey, userRecord.getPartitionKey());
+            assertEquals(stringToEncode, StandardCharsets.UTF_8.decode(userRecord.getData())
+                    .toString());
+        } catch (Exception e) {
+            fail(String.format("Did not expect an exception: {}", e));
+        }
+    }
+
+    @Test
+    public void addUserRecordDoesNotReturnsRecordOnSuccessWhenDisabled() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration();
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes("UTF-8"));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+
+        // Mock a message received from Daemon
+        PutRecordResult prr = PutRecordResult.newBuilder()
+                .setSuccess(true)
+                .setShardId("shard-1")
+                .setSequenceNumber("123")
+                .build();
+        Message m = Message.newBuilder()
+                .setId(new Random().nextLong())
+                .setSourceId(1L) // first message is always 1
+                .setPutRecordResult(prr)
+                .build();
+        producerSpy.getChild().getHandler().onMessage(m);
+
+        // then
+        try {
+            UserRecordResult userRecordResult = f.get(5, TimeUnit.SECONDS);
+            UserRecord userRecord = userRecordResult.getUserRecord();
+            assertNull(streamName, userRecord);
+        } catch (Exception e) {
+            fail(String.format("Did not expect an exception: {}", e));
+        }
+    }
+
+    @Test
+    public void addUserRecordReturnsRecordOnFailureInDaemon() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration()
+                .setReturnUserRecordInFuture(true);
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes("UTF-8"));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+
+        // Mock an error thrown from Daemon
+        producerSpy.getChild().getHandler().onError(new DaemonException("Mocked exception."));
+
+        // then
+        try {
+            f.get(5, TimeUnit.SECONDS);
+            fail("Expected an exception");
+        } catch (TimeoutException e) {
+            fail("Future timed out unexpectedly");
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof KinesisProducerException) {
+                UserRecord userRecord = ((KinesisProducerException) e.getCause()).getUserRecord();
+                assertEquals(streamName, userRecord.getStreamName());
+                assertEquals(partitionKey, userRecord.getPartitionKey());
+                assertEquals(stringToEncode, StandardCharsets.UTF_8.decode(userRecord.getData())
+                        .toString());
+            } else {
+                fail("Got unexpected exception");
+            }
+        }
+    }
+
+    @Test
+    public void addUserRecordReturnsRecordOnFailureUserRecordFailedException() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration()
+                .setReturnUserRecordInFuture(true);
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes("UTF-8"));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+
+        // Mock a message received from Daemon
+        PutRecordResult prr = PutRecordResult.newBuilder()
+                .setSuccess(false)
+                .setShardId("shard-1")
+                .setSequenceNumber("123")
+                .build();
+        Message m = Message.newBuilder()
+                .setId(new Random().nextLong())
+                .setSourceId(1L) // first message is always 1
+                .setPutRecordResult(prr)
+                .build();
+        producerSpy.getChild().getHandler().onMessage(m);
+
+        // then
+        try {
+            f.get(5, TimeUnit.SECONDS);
+            fail("Expected an exception");
+        } catch (TimeoutException e) {
+            fail("Future timed out unexpectedly");
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof UserRecordFailedException) {
+                UserRecord userRecord = ((KinesisProducerException) e.getCause()).getUserRecord();
+                assertEquals(streamName, userRecord.getStreamName());
+                assertEquals(partitionKey, userRecord.getPartitionKey());
+                assertEquals(stringToEncode, StandardCharsets.UTF_8.decode(userRecord.getData())
+                        .toString());
+            } else {
+                fail("Got unexpected exception");
+            }
+        }
+    }
+
+    @Test
+    public void addUserRecordReturnsRecordOnFailureFutureTimedOutException() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration()
+                .setReturnUserRecordInFuture(true)
+                .setUserRecordTimeoutInMillis(1000); // make it timeout
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes(StandardCharsets.UTF_8));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+        // Sleep so the UserRecord times out
+        sleep(2000);
+
+        // then
+        try {
+            f.get(5, TimeUnit.SECONDS);
+            fail("Expected an exception");
+        } catch (TimeoutException e) {
+            fail("Future timed out unexpectedly");
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof FutureTimedOutException) {
+                UserRecord userRecord = ((KinesisProducerException) e.getCause()).getUserRecord();
+                assertEquals(streamName, userRecord.getStreamName());
+                assertEquals(partitionKey, userRecord.getPartitionKey());
+                assertEquals(stringToEncode, StandardCharsets.UTF_8.decode(userRecord.getData())
+                        .toString());
+            } else {
+                fail("Got unexpected exception");
+            }
+        }
+    }
+
+    @Test
+    public void addUserRecordReturnsRecordOnFailureUnexpectedMessageException() throws UnsupportedEncodingException, InterruptedException {
+
+        // given
+        final KinesisProducerConfiguration cfg = buildBasicConfiguration()
+                .setReturnUserRecordInFuture(true);
+        final String streamName = "streamName";
+        final String partitionKey = "partitionKey";
+        final String stringToEncode = "Unit test sample data";
+        final KinesisProducer producerSpy = spy(new KinesisProducer(cfg));
+
+        // when
+        // skip sending the message to daemon so that we can test receiving the message
+        doNothing().when(producerSpy).addMessageToChild(any());
+        ByteBuffer data = ByteBuffer.wrap(stringToEncode.getBytes(StandardCharsets.UTF_8));
+        ListenableFuture<UserRecordResult> f = producerSpy.addUserRecord(streamName, partitionKey, data);
+
+        // Mock an unexpected message received from Daemon
+        PutRecord pr = PutRecord.newBuilder()
+                .setStreamName(streamName)
+                .setPartitionKey(partitionKey)
+                .setData(ByteString.copyFrom(data))
+                .build();
+        Message m = Message.newBuilder()
+                .setId(new Random().nextLong())
+                .setSourceId(1L) // first message is always 1
+                .setPutRecord(pr)
+                .build();
+        producerSpy.getChild().getHandler().onMessage(m);
+
+        try {
+            f.get(5, TimeUnit.SECONDS);
+            fail("Expected an exception");
+        } catch (TimeoutException e) {
+            fail("Future timed out unexpectedly");
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof UnexpectedMessageException) {
+                UserRecord userRecord = ((KinesisProducerException) e.getCause()).getUserRecord();
+                assertEquals(streamName, userRecord.getStreamName());
+                assertEquals(partitionKey, userRecord.getPartitionKey());
+                assertEquals(stringToEncode, StandardCharsets.UTF_8.decode(userRecord.getData()).toString());
+            } else {
+                fail("Got unexpected exception");
+            }
+        }
     }
 
     private void sleep(long millisToSleep) {


### PR DESCRIPTION
*Issue #, if available:*
#76

*Description of changes:*
This commit adds the ability for users to fetch the `UserRecord` in `onSuccess` and `onFailure` in all futures created from `addUserRecord`

- Add a settable config `ReturnUserRecordInFuture` (default false). If enabled, the KPL will store the `UserRecord `associated with an `addUserRecord` in memory and return that` UserRecord` in the exceptions on failure and in `UserRecordResult` on success. If false, no userRecord will be stored and the `UserRecord` values in the Exceptions and `UserRecordResult` will be null.
- Adds the `UserRecord` in the `UserRecordResult`
- Create a superclass `KinesisProducerException` which all KPL exceptions extend from. This class contains a `UserRecord` which is populated if `ReturnUserRecordInFuture` is set to true
- Add Javadoc for exceptions


*Testing:*
Ran SampleProducer

`onSuccess`
```
[pool-6-thread-150] INFO software.amazon.kinesis.producer.sample.SampleProducer - Successfully put UserRecord UserRecord(streamName=kpltest, streamARN=null, partitionKey=1753482510482, explicitHashKey=37836790953609139420823924948284851877, data=java.nio.HeapByteBufferR[pos=128 lim=128 cap=128], schema=null) with data 1879 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

Induced a `ResourceNotFound` to test `onFailure`
```
[pool-6-thread-289] ERROR software.amazon.kinesis.producer.sample.SampleProducer - UserRecord UserRecord(streamName=kpltest, streamARN=null, partitionKey=1753482546126, explicitHashKey=145514194416976864704373545402421673781, data=java.nio.HeapByteBufferR[pos=128 lim=128 cap=128], schema=null) with data 1999 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa failed to put - Expired : Record 1999 has reached expiration. Previous failure - ResourceNotFoundException : Stream kpltest under account 705755217893 not found.
[pool-6-thread-289] ERROR software.amazon.kinesis.producer.sample.SampleProducer - Exception during put
software.amazon.kinesis.producer.UserRecordFailedException
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler.onPutRecordResult(KinesisProducer.java:242)
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler.access$100(KinesisProducer.java:165)
	at software.amazon.kinesis.producer.KinesisProducer$MessageHandler$1.run(KinesisProducer.java:172)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
