### PR TITLE
Bootstrap script fix for Mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,19 @@
 /third_party
 /java/amazon-kinesis-producer/src/main/resources/amazon-kinesis-producer-native-binaries/**/*
 
+# CMake build files
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+
+# Build output
+kinesis_producer
+test_driver
+tests
+aws-sdk-cpp/
+aws-sdk-cpp-build/
+
 # VS Code
 .vscode/
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,9 +30,9 @@ CA_CERT="https://curl.se/ca/cacert.pem"
 INSTALL_DIR=$(pwd)/third_party
 
 # Cleanup any earlier version of the third party directory and links to it.
-rm -f b2
-rm -rf $INSTALL_DIR
-mkdir -p $INSTALL_DIR
+#rm -f b2
+#rm -rf $INSTALL_DIR
+#mkdir -p $INSTALL_DIR
 
 #Figure out the release type from os. The release type will be used to determine the final storage location
 # of the native binary
@@ -128,7 +128,11 @@ if [ ! -d "openssl-${OPENSSL_VERSION}" ]; then
   OPTS="threads no-shared no-idea no-camellia no-seed no-bf no-cast no-rc2 no-rc5 no-md2 no-mdc2 no-ssl2 no-ssl3 no-capieng no-dso --prefix=$INSTALL_DIR --libdir=lib"
 
   if [[ $(uname) == 'Darwin' ]]; then
-    OPTS="$OPTS darwin64-x86_64-cc enable-ec_nistp_64_gcc_128"
+    if [[ $(uname -m) == 'arm64' ]]; then
+      OPTS="$OPTS darwin64-arm64-cc enable-ec_nistp_64_gcc_128"
+    else
+      OPTS="$OPTS darwin64-x86_64-cc enable-ec_nistp_64_gcc_128"
+    fi
     silence ./Configure $OPTS
   elif [[ $(uname) == MINGW* ]]; then
     silence ./Configure mingw64 $OPTS

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,9 +30,9 @@ CA_CERT="https://curl.se/ca/cacert.pem"
 INSTALL_DIR=$(pwd)/third_party
 
 # Cleanup any earlier version of the third party directory and links to it.
-#rm -f b2
-#rm -rf $INSTALL_DIR
-#mkdir -p $INSTALL_DIR
+rm -f b2
+rm -rf $INSTALL_DIR
+mkdir -p $INSTALL_DIR
 
 #Figure out the release type from os. The release type will be used to determine the final storage location
 # of the native binary


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fixed bootstrap script to also account for ARM64 on Mac OS. Added CMake output files to .gitignore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.