### PR TITLE
Add constructor for UserRecordFailedException for backwards compatability

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordFailedException.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/UserRecordFailedException.java
@@ -29,6 +29,10 @@ public class UserRecordFailedException extends KinesisProducerException {
         this.result = result;
     }
 
+    public UserRecordFailedException(UserRecordResult result) {
+        this(result, null);
+    }
+
     public UserRecordResult getResult() {
         return result;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Re-add the removed constructor for `UserRecordFailedException` from #659 to support backwards compatability

https://github.com/awslabs/amazon-kinesis-producer/pull/659#discussion_r2301586033

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
