### PR TITLE
fixed documentation to match variable name

### DIFF
--- a/java/amazon-kinesis-producer-sample/default_config.properties
+++ b/java/amazon-kinesis-producer-sample/default_config.properties
@@ -22,7 +22,7 @@ AggregationEnabled = true
 # Maximum number of items to pack into an aggregated record.
 #
 # There should be normally no need to adjust this. If you want to limit the
-# time records spend buffering, look into record_max_buffered_time instead.
+# time records spend buffering, look into RecordMaxBufferedTime instead.
 #
 # Default: 4294967295
 # Minimum: 1
@@ -32,7 +32,7 @@ AggregationMaxCount = 4294967295
 # Maximum number of bytes to pack into an aggregated Kinesis record.
 #
 # There should be normally no need to adjust this. If you want to limit the
-# time records spend buffering, look into record_max_buffered_time instead.
+# time records spend buffering, look into RecordMaxBufferedTime instead.
 #
 # If a record has more data by itself than this limit, it will bypass the
 # aggregator. Note the backend enforces a limit of 1MB on record size. If
@@ -46,7 +46,7 @@ AggregationMaxSize = 51200
 # Maximum number of items to pack into an PutRecords request.
 #
 # There should be normally no need to adjust this. If you want to limit the
-# time records spend buffering, look into record_max_buffered_time instead.
+# time records spend buffering, look into RecordMaxBufferedTime instead.
 #
 # Default: 500
 # Minimum: 1
@@ -56,7 +56,7 @@ CollectionMaxCount = 500
 # Maximum amount of data to send with a PutRecords request.
 #
 # There should be normally no need to adjust this. If you want to limit the
-# time records spend buffering, look into record_max_buffered_time instead.
+# time records spend buffering, look into RecordMaxBufferedTime instead.
 #
 # Records larger than the limit will still be sent, but will not be grouped
 # with others.
@@ -91,7 +91,7 @@ ConnectTimeout = 6000
 # If false, the KPL will automatically retry throttled puts. The KPL performs
 # backoff for shards that it has received throttling errors from, and will
 # avoid flooding them with retries. Note that records may fail from
-# expiration (see record_ttl) if they get delayed for too long because of
+# expiration (see RecordTtl) if they get delayed for too long because of
 # throttling.
 #
 # Default: false
@@ -230,7 +230,7 @@ RateLimit = 150
 #
 # Failures and retries can additionally increase the amount of time records
 # spend in the KPL. If your application cannot tolerate late records, use the
-# record_ttl setting to drop records that do not get transmitted in time.
+# RecordTtl setting to drop records that do not get transmitted in time.
 #
 # Setting this too low can negatively impact throughput.
 #
@@ -247,10 +247,10 @@ RecordMaxBufferedTime = 100
 # this setting.
 #
 # If you do not wish to lose records and prefer to retry indefinitely, set
-# record_ttl to a large value like INT_MAX. This has the potential to cause
+# RecordTtl to a large value like INT_MAX. This has the potential to cause
 # head-of-line blocking if network issues or throttling occur. You can
 # respond to such situations by using the metrics reporting functions of the
-# KPL. You may also set fail_if_throttled to true to prevent automatic
+# KPL. You may also set FailIfThrottled to true to prevent automatic
 # retries in case of throttling.
 #
 # Default: 30000
@@ -282,7 +282,7 @@ RecordTtl = 30000
 RequestTimeout = 6000
 
 # Verify the endpoint's certificate. Do not disable unless using
-# custom_endpoint for testing. Never disable this in production.
+# KinesisEndpoint for testing. Never disable this in production.
 #
 # Default: true
 VerifyCertificate = true


### PR DESCRIPTION
Updating documentation in the sample app to match the variable names (record_max_buffered_time -> RecordMaxBufferedTime)