### PR TITLE
Removing STS from native code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,7 @@ set(STATIC_LIBS
 find_package(Protobuf REQUIRED)
 find_package(Threads)
 find_package(ZLIB)
-find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring sts)
+find_package(AWSSDK REQUIRED COMPONENTS kinesis monitoring)
 
 # Specify the output directory for generated protobuf files
 set(PROTO_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/aws/kinesis/protobuf/)

--- a/aws/kinesis/core/configuration.h
+++ b/aws/kinesis/core/configuration.h
@@ -429,26 +429,6 @@ class Configuration : private boost::noncopyable {
       return proxy_password_;
   }
 
-  // Use a custom Sts endpoint.
-  //
-  // Note this does not accept protocols or paths, only host names or ip
-  // addresses. There is no way to disable TLS. The KPL always connects with
-  // TLS.
-  //
-  // Expected pattern: ^([A-Za-z0-9-\\.]+)?$
-  const std::string& sts_endpoint() const noexcept {
-    return sts_endpoint_;
-  }
-
-  // Server port to connect to for STS.
-  //
-  // Default: 443
-  // Minimum: 1
-  // Maximum (inclusive): 65535
-  size_t sts_port() const noexcept {
-    return sts_port_;
-  }
-
   /// Indicates whether the SDK clients should use a thread pool or not
   /// \return true if the client should use a thread pool, false otherwise
   bool use_thread_pool() const noexcept {
@@ -1042,43 +1022,6 @@ class Configuration : private boost::noncopyable {
       return *this;
   }
 
-  // Use a custom STS endpoint.
-  //
-  // Note this does not accept protocols or paths, only host names or ip
-  // addresses. There is no way to disable TLS. The KPL always connects with
-  // TLS.
-  //
-  // Expected pattern: ^([A-Za-z0-9-\\.]+)?$
-  Configuration& sts_endpoint(std::string val) {
-    static std::regex pattern(
-            "^([A-Za-z0-9-\\.]+)?$",
-            std::regex::ECMAScript | std::regex::optimize);
-    if (!std::regex_match(val, pattern)) {
-      std::string err;
-      err += "sts_endpoint must match the pattern ^([A-Za-z0-9-\\.]+)?$, got ";
-      err += val;
-      throw std::runtime_error(err);
-    }
-    sts_endpoint_ = val;
-    return *this;
-  }
-
-  // Server port to connect to for STS.
-  //
-  // Default: 443
-  // Minimum: 1
-  // Maximum (inclusive): 65535
-  Configuration& sts_port(size_t val) {
-    if (val < 1ull || val > 65535ull) {
-      std::string err;
-      err += "sts_port must be between 1 and 65535, got ";
-      err += std::to_string(val);
-      throw std::runtime_error(err);
-    }
-    sts_port_ = val;
-    return *this;
-  }
-
   /// Enables or disable the use of a thread pool for the SDK Client.
   /// Default: false
   /// \param val whether or not to use a thread pool
@@ -1150,8 +1093,6 @@ class Configuration : private boost::noncopyable {
     proxy_port(c.proxy_port());
     proxy_user_name(c.proxy_user_name());
     proxy_password(c.proxy_password());
-    sts_endpoint(c.sts_endpoint());
-    sts_port(c.sts_port());
 
     if (c.thread_config() == ::aws::kinesis::protobuf::Configuration_ThreadConfig::Configuration_ThreadConfig_POOLED) {
       use_thread_pool(true);
@@ -1198,8 +1139,6 @@ class Configuration : private boost::noncopyable {
   size_t proxy_port_ = 443;
   std::string proxy_user_name_ = "";
   std::string proxy_password_ = "";
-  std::string sts_endpoint_ = "";
-  size_t sts_port_ = 443;
 
   bool use_thread_pool_ = true;
   uint32_t thread_pool_size_ = 64;

--- a/aws/kinesis/core/kinesis_producer.h
+++ b/aws/kinesis/core/kinesis_producer.h
@@ -53,7 +53,6 @@ class KinesisProducer : boost::noncopyable {
         shutdown_(false) {
     create_kinesis_client(ca_path, ca_file);
     create_cw_client(ca_path, ca_file);
-    create_sts_client(ca_path, ca_file);
     create_metrics_manager();
     report_outstanding();
     message_drainer_ = aws::thread([this] { this->drain_messages(); });
@@ -78,8 +77,6 @@ class KinesisProducer : boost::noncopyable {
   void create_kinesis_client(const std::string& ca_path, const std::string& ca_file);
 
   void create_cw_client(const std::string& ca_path, const std::string& ca_file);
-
-  void create_sts_client(const std::string& ca_path, const std::string& ca_file);
 
   Pipeline* create_pipeline(const std::string& stream);
 
@@ -107,7 +104,6 @@ class KinesisProducer : boost::noncopyable {
       cw_creds_provider_;
   std::shared_ptr<Aws::Kinesis::KinesisClient> kinesis_client_;
   std::shared_ptr<Aws::CloudWatch::CloudWatchClient> cw_client_;
-  std::shared_ptr<Aws::STS::STSClient> sts_client_;
   std::shared_ptr<aws::utils::Executor> executor_;
 
   std::shared_ptr<IpcManager> ipc_manager_;

--- a/aws/kinesis/protobuf/config.proto
+++ b/aws/kinesis/protobuf/config.proto
@@ -41,8 +41,6 @@ message Configuration {
   optional uint64 proxy_port = 27 [default = 443];
   optional string proxy_user_name = 28 [default = ""];
   optional string proxy_password = 29 [default = ""];
-  optional string sts_endpoint = 32 [default = ""];
-  optional uint64 sts_port = 33 [default = 443];
   enum ThreadConfig {
     PER_REQUEST = 0;
     POOLED = 1;

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -250,7 +250,7 @@ if [ ! -d "aws-sdk-cpp" ]; then
   cd aws-sdk-cpp-build
 
   silence $CMAKE \
-    -DBUILD_ONLY="kinesis;monitoring;sts" \
+    -DBUILD_ONLY="kinesis;monitoring" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DSTATIC_LINKING=1 \
     -DCMAKE_PREFIX_PATH="$INSTALL_DIR" \

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/KinesisProducerConfiguration.java
@@ -900,6 +900,7 @@ public class KinesisProducerConfiguration {
     }
 
     /**
+     * This code does not do anything. It's kept for backward compatibility.
      * Get a custom STS endpoint.
      *
      * <p>
@@ -913,6 +914,7 @@ public class KinesisProducerConfiguration {
     }
 
     /**
+     * This code does not do anything. It's kept for backward compatibility.
      * Server port to connect to for STS.
      *
      * <p><b>Default</b>: 443
@@ -1609,6 +1611,8 @@ public class KinesisProducerConfiguration {
     }
 
     /**
+     * This code does not do anything. It's kept for backward compatibility.
+     *
      * Use a custom STS endpoint.
      *
      * <p>
@@ -1626,6 +1630,8 @@ public class KinesisProducerConfiguration {
     }
 
     /**
+     * This code does not do anything. It's kept for backward compatibility.
+     *
      * Server port to connect to for STS.
      *
      * <p><b>Default</b>: 443
@@ -1777,8 +1783,6 @@ public class KinesisProducerConfiguration {
                 .setProxyPort(proxyPort)
                 .setProxyUserName(proxyUserName)
                 .setProxyPassword(proxyPassword)
-                .setStsEndpoint(stsEndpoint)
-                .setStsPort(stsPort)
                 .setThreadConfig(threadingModel.threadConfig);
         //@formatter:on
         if (threadPoolSize > 0) {

--- a/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/software/amazon/kinesis/producer/KinesisProducerTest.java
@@ -78,7 +78,6 @@ public class KinesisProducerTest {
     private static final int port = PortFactory.findFreePort();
     private static final int sts_port = PortFactory.findFreePort();
     private ClientAndServer mockServer;
-    private ClientAndServer stsMockServer;
 
     private static class RotatingAwsCredentialsProvider implements AwsCredentialsProvider {
         private final List<AwsCredentials> creds;
@@ -104,39 +103,11 @@ public class KinesisProducerTest {
                         .withStatusCode(403)
                         .withBody("{\"status\":\"Expected error\",\"message\":\"test\"}")
         );
-
-        stsMockServer = startClientAndServer(sts_port);
-        stsMockServer.when(
-                request()
-                        .withMethod("POST")
-        ).respond(
-                response()
-                        .withStatusCode(200)
-                        .withBody(
-                                // https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
-                                "<?xml version=\"1.0\" ?>\n" +
-                                        "<GetCallerIdentityResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">\n" +
-                                        "  <GetCallerIdentityResult>\n" +
-                                        "  <Arn>arn:aws:iam::123456789012:user/Alice</Arn>\n" +
-                                        "  <UserId>AIDACKCEVSQ6C2EXAMPLE</UserId>\n" +
-                                        "  <Account>123456789012</Account>\n" +
-                                        "  </GetCallerIdentityResult>\n" +
-                                        "  <ResponseMetadata>\n" +
-                                        "    <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>\n" +
-                                        "  </ResponseMetadata>\n" +
-                                        // This trailing \0 is important for AWSXMLClient to parse this snippet
-                                        "</GetCallerIdentityResponse>\0"
-                        )
-                        .withHeaders(
-                                new Header("Content-Type", "text/xml")
-                        )
-        );
     }
 
     @After
     public void stopServer() {
         mockServer.stop();
-        stsMockServer.stop();
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
Removing STS dependency from the native code. The java interface is kept to preserve backward compatibility. In native code streamArn is replaced with empty string for now.

This change reverts commits 

https://github.com/awslabs/amazon-kinesis-producer/commit/31fb6a6b7d5ea6587ab1d34e37ba55545011458d
https://github.com/awslabs/amazon-kinesis-producer/commit/4c91629c3446ff844beadd1b6f8aedcf1803ded2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
