### PR TITLE
Prepare for KPL release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.8
 * [#691](https://github.com/awslabs/amazon-kinesis-producer/pull/691) Add UnhealthyDaemon metric emission to CloudWatch when daemon health check triggers restart
 * [#692](https://github.com/awslabs/amazon-kinesis-producer/pull/692) Add queue status logging to improve KPL observability
+* [#697](https://github.com/awslabs/amazon-kinesis-producer/pull/697) Bump com.fasterxml.jackson.core:jackson-databind
 * [#698](https://github.com/awslabs/amazon-kinesis-producer/pull/698) Bump com.fasterxml.jackson.core:jackson-core
 * [#699](https://github.com/awslabs/amazon-kinesis-producer/pull/699) Update debug log for starting native process
 * [#701](https://github.com/awslabs/amazon-kinesis-producer/pull/701) Send credentials over IPC rather than the command line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+## 1.0.8
+* [#691](https://github.com/awslabs/amazon-kinesis-producer/pull/691) Add UnhealthyDaemon metric emission to CloudWatch when daemon health check triggers restart
+* [#692](https://github.com/awslabs/amazon-kinesis-producer/pull/692) Add queue status logging to improve KPL observability
+* [#698](https://github.com/awslabs/amazon-kinesis-producer/pull/698) Bump com.fasterxml.jackson.core:jackson-core
+* [#699](https://github.com/awslabs/amazon-kinesis-producer/pull/699) Update debug log for starting native process
+* [#701](https://github.com/awslabs/amazon-kinesis-producer/pull/701) Send credentials over IPC rather than the command line
+* [#702](https://github.com/awslabs/amazon-kinesis-producer/pull/702) Upgrade OpenSSL to 3.5.7 and libcurl to 8.22.0
+
 ## 1.0.7
 * [#674](https://github.com/awslabs/amazon-kinesis-producer/pull/674) Add C++ daemon health check
 * [#681](https://github.com/awslabs/amazon-kinesis-producer/pull/681) Use activity monitoring for health check

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This is a restatement of the [notice published](https://docs.aws.amazon.com/stre
 ## 1.0.8
 * [#691](https://github.com/awslabs/amazon-kinesis-producer/pull/691) Add UnhealthyDaemon metric emission to CloudWatch when daemon health check triggers restart
 * [#692](https://github.com/awslabs/amazon-kinesis-producer/pull/692) Add queue status logging to improve KPL observability
+* [#697](https://github.com/awslabs/amazon-kinesis-producer/pull/697) Bump com.fasterxml.jackson.core:jackson-databind
 * [#698](https://github.com/awslabs/amazon-kinesis-producer/pull/698) Bump com.fasterxml.jackson.core:jackson-core
 * [#699](https://github.com/awslabs/amazon-kinesis-producer/pull/699) Update debug log for starting native process
 * [#701](https://github.com/awslabs/amazon-kinesis-producer/pull/701) Send credentials over IPC rather than the command line

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ This is a restatement of the [notice published](https://docs.aws.amazon.com/stre
 
 ## Release Notes
 
+## 1.0.8
+* [#691](https://github.com/awslabs/amazon-kinesis-producer/pull/691) Add UnhealthyDaemon metric emission to CloudWatch when daemon health check triggers restart
+* [#692](https://github.com/awslabs/amazon-kinesis-producer/pull/692) Add queue status logging to improve KPL observability
+* [#698](https://github.com/awslabs/amazon-kinesis-producer/pull/698) Bump com.fasterxml.jackson.core:jackson-core
+* [#699](https://github.com/awslabs/amazon-kinesis-producer/pull/699) Update debug log for starting native process
+* [#701](https://github.com/awslabs/amazon-kinesis-producer/pull/701) Send credentials over IPC rather than the command line
+* [#702](https://github.com/awslabs/amazon-kinesis-producer/pull/702) Upgrade OpenSSL to 3.5.7 and libcurl to 8.22.0
+
 ## 1.0.7
 * [#674](https://github.com/awslabs/amazon-kinesis-producer/pull/674) Add C++ daemon health check
 * [#681](https://github.com/awslabs/amazon-kinesis-producer/pull/681) Use activity monitoring for health check

--- a/aws/kinesis/core/kinesis_producer.cc
+++ b/aws/kinesis/core/kinesis_producer.cc
@@ -39,7 +39,7 @@ struct EndpointConfiguration {
           cloudwatch_endpoint_(cloudwatch_endpoint) {}
 };
 
-const constexpr char* kVersion = "1.0.7N";
+const constexpr char* kVersion = "1.0.8N";
 const std::unordered_map< std::string, EndpointConfiguration > kRegionEndpointOverride = {
   { "cn-north-1", { "kinesis.cn-north-1.amazonaws.com.cn", "monitoring.cn-north-1.amazonaws.com.cn" } },
   { "cn-northwest-1", { "kinesis.cn-northwest-1.amazonaws.com.cn", "monitoring.cn-northwest-1.amazonaws.com.cn" } }

--- a/java/amazon-kinesis-producer-sample/pom.xml
+++ b/java/amazon-kinesis-producer-sample/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-producer-sample</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <build>
         <sourceDirectory>src</sourceDirectory>
         <plugins>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-producer</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/amazon-kinesis-producer/pom.xml
+++ b/java/amazon-kinesis-producer/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.amazon.kinesis</groupId>
     <artifactId>amazon-kinesis-producer</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <name>Amazon Kinesis Producer Library</name>
 
     <scm>

--- a/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
+++ b/java/amazon-kinesis-producer/src/main/java/software/amazon/kinesis/producer/GlueSchemaRegistrySerializerInstance.java
@@ -11,7 +11,7 @@ import com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySeria
 public final class GlueSchemaRegistrySerializerInstance {
 
     private volatile GlueSchemaRegistrySerializer instance = null;
-    private static final String USER_AGENT_APP_NAME = "kpl-1.0.7";
+    private static final String USER_AGENT_APP_NAME = "kpl-1.0.8";
 
     /**
      * Instantiate GlueSchemaRegistrySerializer using the KinesisProducerConfiguration.


### PR DESCRIPTION
## 1.0.8
* [#691](https://github.com/awslabs/amazon-kinesis-producer/pull/691) Add UnhealthyDaemon metric emission to CloudWatch when daemon health check triggers restart
* [#692](https://github.com/awslabs/amazon-kinesis-producer/pull/692) Add queue status logging to improve KPL observability
* [#697](https://github.com/awslabs/amazon-kinesis-producer/pull/697) Bump com.fasterxml.jackson.core:jackson-databind
* [#698](https://github.com/awslabs/amazon-kinesis-producer/pull/698) Bump com.fasterxml.jackson.core:jackson-core
* [#699](https://github.com/awslabs/amazon-kinesis-producer/pull/699) Update debug log for starting native process
* [#701](https://github.com/awslabs/amazon-kinesis-producer/pull/701) Send credentials over IPC rather than the command line
* [#702](https://github.com/awslabs/amazon-kinesis-producer/pull/702) Upgrade OpenSSL to 3.5.7 and libcurl to 8.22.0
